### PR TITLE
added support for multiple module path

### DIFF
--- a/src/main/java/org/wildfly/plugin/server/DomainServer.java
+++ b/src/main/java/org/wildfly/plugin/server/DomainServer.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import org.codehaus.plexus.util.StringUtils;
 import org.jboss.as.controller.client.helpers.domain.DomainClient;
 import org.jboss.as.controller.client.helpers.domain.ServerIdentity;
 import org.jboss.as.controller.client.helpers.domain.ServerStatus;
@@ -159,8 +160,15 @@ final class DomainServer extends Server {
         // cmd.add("-Djboss.host.default.config=" + config.getHostConfig());
         cmd.add("-jar");
         cmd.add(modulesJar.getAbsolutePath());
+
+        List<String> modulePaths = new ArrayList<String>();
+        for (File eachModuleDir : serverInfo.getModulesDir()) {
+            modulePaths.add(eachModuleDir.getAbsolutePath());
+        }
+        String modulePathsArg = StringUtils.join(modulePaths.iterator(), File.pathSeparator);
         cmd.add("-mp");
-        cmd.add(serverInfo.getModulesDir().getAbsolutePath());
+        cmd.add(modulePathsArg);
+
         cmd.add("org.jboss.as.process-controller");
         cmd.add("-jboss-home");
         cmd.add(jbossHome.getAbsolutePath());

--- a/src/main/java/org/wildfly/plugin/server/RunMojo.java
+++ b/src/main/java/org/wildfly/plugin/server/RunMojo.java
@@ -107,7 +107,7 @@ public class RunMojo extends DeployMojo {
     private String version;
 
     /**
-     * The modules path to use.
+     * The modules path to use. If you have multiple module paths, separate them with semi-colon (;)
      */
     @Parameter(alias = "modules-path", property = PropertyNames.MODULES_PATH)
     private String modulesPath;
@@ -166,8 +166,10 @@ public class RunMojo extends DeployMojo {
             javaHome = this.javaHome;
         }
         final ServerInfo serverInfo = ServerInfo.of(this, javaHome, jbossHome, modulesPath, jvmArgs, serverConfig, propertiesFile, startupTimeout);
-        if (!serverInfo.getModulesDir().isDirectory()) {
-            throw new MojoExecutionException(String.format("Modules path '%s' is not a valid directory.", modulesPath));
+        for (File eachModuleDir : serverInfo.getModulesDir()) {
+            if (!eachModuleDir.isDirectory()) {
+                throw new MojoExecutionException(String.format("Modules path '%s' is not a valid directory.", eachModuleDir));
+            }
         }
 
         // Print some server information

--- a/src/main/java/org/wildfly/plugin/server/ServerInfo.java
+++ b/src/main/java/org/wildfly/plugin/server/ServerInfo.java
@@ -23,6 +23,8 @@
 package org.wildfly.plugin.server;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.wildfly.plugin.common.ConnectionInfo;
 import org.wildfly.plugin.common.Files;
@@ -35,7 +37,7 @@ import org.wildfly.plugin.common.Files;
 class ServerInfo {
     private final ConnectionInfo connectionInfo;
     private final File jbossHome;
-    private final File modulesDir;
+    private final File[] modulesDir;
     private final String[] jvmArgs;
     private final String javaHome;
     private final String serverConfig;
@@ -46,7 +48,19 @@ class ServerInfo {
         this.connectionInfo = connectionInfo;
         this.javaHome = javaHome;
         this.jbossHome = jbossHome;
-        this.modulesDir = (modulesDir == null ? Files.createFile(jbossHome, "modules") : new File(modulesDir));
+
+        if (modulesDir == null) {
+            this.modulesDir = new File[]{Files.createFile(jbossHome, "modules")};
+        } else {
+            String[] modulePaths = modulesDir.split(";");
+            List<File> pathCollection = new ArrayList<>();
+            for (String each : modulePaths) {
+                pathCollection.add(new File(each));
+            }
+            this.modulesDir = pathCollection.toArray(new File[pathCollection.size()]);
+        }
+
+
         this.jvmArgs = jvmArgs;
         this.serverConfig = serverConfig;
         this.propertiesFile = propertiesFile;
@@ -89,11 +103,11 @@ class ServerInfo {
     }
 
     /**
-     * The directory for all the modules.
+     * The directories for all the modules.
      *
-     * @return the modules directory
+     * @return the modules directories
      */
-    public File getModulesDir() {
+    public File[] getModulesDir() {
         return modulesDir;
     }
 

--- a/src/main/java/org/wildfly/plugin/server/StandaloneServer.java
+++ b/src/main/java/org/wildfly/plugin/server/StandaloneServer.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.codehaus.plexus.util.StringUtils;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.wildfly.plugin.common.Files;
 import org.wildfly.plugin.common.IoUtils;
@@ -125,8 +126,15 @@ final class StandaloneServer extends Server {
         cmd.add("-Dlogging.configuration=file:" + jbossHome + CONFIG_PATH + "logging.properties");
         cmd.add("-jar");
         cmd.add(modulesJar.getAbsolutePath());
+
+        List<String> modulePaths = new ArrayList<String>();
+        for (File eachModuleDir : serverInfo.getModulesDir()) {
+            modulePaths.add(eachModuleDir.getAbsolutePath());
+        }
+        String modulePathsArg = StringUtils.join(modulePaths.iterator(), File.pathSeparator);
         cmd.add("-mp");
-        cmd.add(serverInfo.getModulesDir().getAbsolutePath());
+        cmd.add(modulePathsArg);
+
         cmd.add("org.jboss.as.standalone");
         cmd.add("-Djboss.home.dir=" + jbossHome);
         if (serverInfo.getServerConfig() != null) {

--- a/src/main/java/org/wildfly/plugin/server/StartMojo.java
+++ b/src/main/java/org/wildfly/plugin/server/StartMojo.java
@@ -111,7 +111,7 @@ public class StartMojo extends AbstractServerConnection {
     private String version;
 
     /**
-     * The modules path to use.
+     * The modules path to use. If you have multiple module paths, separate them with semi-colon (;)
      */
     @Parameter(alias = "modules-path", property = PropertyNames.MODULES_PATH)
     private String modulesPath;
@@ -163,8 +163,10 @@ public class StartMojo extends AbstractServerConnection {
             javaHome = this.javaHome;
         }
         final ServerInfo serverInfo = ServerInfo.of(this, javaHome, jbossHome, modulesPath, jvmArgs, serverConfig, propertiesFile, startupTimeout);
-        if (!serverInfo.getModulesDir().isDirectory()) {
-            throw new MojoExecutionException(String.format("Modules path '%s' is not a valid directory.", modulesPath));
+        for (File eachModuleDir : serverInfo.getModulesDir()) {
+            if (!eachModuleDir.isDirectory()) {
+                throw new MojoExecutionException(String.format("Modules path '%s' is not a valid directory.", eachModuleDir));
+            }
         }
         // Print some server information
         log.info(String.format("JAVA_HOME=%s", javaHome));


### PR DESCRIPTION
I've added the feature to support multiple module-path in configuration

The use case would be

I run `mvn wildfly:run` with project that depends on custom Wildfly modules (which also depends on Wildfly standard modules) with this option I can freely use the standard distribution of Wildfly
