### PR TITLE
Skip parameter for execute-commands goal

### DIFF
--- a/src/main/java/org/wildfly/plugin/cli/ExecuteCommandsMojo.java
+++ b/src/main/java/org/wildfly/plugin/cli/ExecuteCommandsMojo.java
@@ -52,6 +52,12 @@ import org.wildfly.plugin.common.AbstractServerConnection;
 public class ExecuteCommandsMojo extends AbstractServerConnection {
 
     /**
+     * {@code true} if commands execution should be skipped.
+     */
+    @Parameter(defaultValue = "false")
+    private boolean skip;
+
+    /**
      * The commands to execute.
      */
     @Parameter(alias = "execute-commands")
@@ -64,6 +70,10 @@ public class ExecuteCommandsMojo extends AbstractServerConnection {
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
+        if (skip) {
+            getLog().debug("Skipping commands execution");
+            return;
+        }
         getLog().debug("Executing commands");
         synchronized (CLIENT_LOCK) {
             final ModelControllerClient client = getClient();


### PR DESCRIPTION
Contains support for skip parameter in execute-commands goal that enables to skip commands execution.
This parameter is available in other goals but it is missing in execute-commands goal.