### PR TITLE
Introduce ignoreFailures parameter to execute-commands goal

### DIFF
--- a/plugin/src/main/java/org/wildfly/plugin/cli/Commands.java
+++ b/plugin/src/main/java/org/wildfly/plugin/cli/Commands.java
@@ -81,6 +81,12 @@ public class Commands {
     private List<File> scripts = new ArrayList<File>();
 
     /**
+     * If a command fails, go on anyway.
+     */
+    @Parameter
+    private boolean ignoreFailures = false;
+
+    /**
      * Indicates whether or not commands should be executed in a batch.
      *
      * @return {@code true} if commands should be executed in a batch, otherwise
@@ -155,7 +161,8 @@ public class Commands {
                     } catch (CommandFormatException e) {
                         throw new IllegalArgumentException(String.format("Command '%s' is invalid. %s", line, e.getLocalizedMessage()), e);
                     } catch (CommandLineException e) {
-                        throw new IllegalArgumentException(String.format("Command execution failed for command '%s'. %s", line, e.getLocalizedMessage()), e);
+                        if(!ignoreFailures)
+                            throw new IllegalArgumentException(String.format("Command execution failed for command '%s'. %s", line, e.getLocalizedMessage()), e);
                     }
                     line = reader.readLine();
 
@@ -173,7 +180,8 @@ public class Commands {
             } catch (CommandFormatException e) {
                 throw new IllegalArgumentException(String.format("Command '%s' is invalid. %s", cmd, e.getLocalizedMessage()), e);
             } catch (CommandLineException e) {
-                throw new IllegalArgumentException(String.format("Command execution failed for command '%s'. %s", cmd, e.getLocalizedMessage()), e);
+                if(!ignoreFailures)
+                    throw new IllegalArgumentException(String.format("Command execution failed for command '%s'. %s", cmd, e.getLocalizedMessage()), e);
             }
         }
     }
@@ -190,7 +198,7 @@ public class Commands {
                 }
             }
             final ModelNode result = ctx.getModelControllerClient().execute(batch.toRequest());
-            if (!ServerOperations.isSuccessfulOutcome(result)) {
+            if (!ignoreFailures && !ServerOperations.isSuccessfulOutcome(result)) {
                 throw new IllegalArgumentException(ServerOperations.getFailureDescriptionAsString(result));
             }
         }

--- a/plugin/src/site/apt/examples/execute-commands-example.apt.vm
+++ b/plugin/src/site/apt/examples/execute-commands-example.apt.vm
@@ -12,7 +12,10 @@ Execute Commands Examples
 
 * Execute commands
 
-  The example below shows how to add a debug logger with a debug log file:
+  The example below shows how to add a debug logger with a debug log file.
+  The ignoreFailures parameter means that if a command fails, the build will continue,
+  eg. you can run these 'add' commands idempotently without failing due to already
+  existing resources.
 
 ----------
 <project>
@@ -27,6 +30,7 @@ Execute Commands Examples
                 <version>${project.version}</version>
                 <configuration>
                     <execute-commands>
+                        <ignoreFailures>true</ignoreFailures>
                         <commands>
                             <command>/subsystem=logging/file-handler=debug:add(level=DEBUG,autoflush=true,file={"relative-to"=>"jboss.server.log.dir", "path"=>"debug.log"})</command>
                             <command>/subsystem=logging/logger=org.jboss.as:add(level=DEBUG,handlers=[debug])</command>


### PR DESCRIPTION
This is useful for making the goal idempotent (eg. not failing if called repeatedly)