### PR TITLE
jms-queue command -> ClassNotFoundException: org.jboss.logmanager.LogContextSelector

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -145,11 +145,11 @@
                     <groupId>org.jboss.logging</groupId>
                     <artifactId>jboss-logging-processor</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>org.jboss.logmanager</groupId>
-                    <artifactId>jboss-logmanager</artifactId>
-                </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>jboss-logmanager</artifactId>
         </dependency>
         <dependency>
             <groupId>org.wildfly.core</groupId>


### PR DESCRIPTION
## Problem
Executing `jms-queue add` command using current `master` (`1.1.0.Alpha3-SNAPSHOT`) version  causes an error:

    A required class was missing while executing 
      org.wildfly.plugins:wildfly-maven-plugin:1.1.0.Alpha3-SNAPSHOT:run: 
      org/jboss/logmanager/LogContextSelector

Error call stack:

    Caused by: java.lang.NoClassDefFoundError: org/jboss/logmanager/LogContextSelector
        at org.jboss.as.cli.embedded.EmbeddedControllerHandlerRegistrar.registerEmbeddedCommands(EmbeddedControllerHandlerRegistrar.java:89)
        at org.jboss.as.cli.impl.CommandContextImpl.initCommands(CommandContextImpl.java:484)
        at org.jboss.as.cli.impl.CommandContextImpl.<init>(CommandContextImpl.java:283)
        at org.jboss.as.cli.impl.CommandContextFactoryImpl.newCommandContext(CommandContextFactoryImpl.java:44)
        at org.wildfly.plugin.cli.Commands.create(Commands.java:213)
        at org.wildfly.plugin.cli.Commands.execute(Commands.java:128)
        at org.wildfly.plugin.deployment.AbstractDeployment.executeDeployment(AbstractDeployment.java:118)
        at org.wildfly.plugin.server.RunMojo.doExecute(RunMojo.java:218)
        at org.wildfly.plugin.deployment.AbstractDeployment.execute(AbstractDeployment.java:111)
        at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:134)
        ... 21 more
    Caused by: java.lang.ClassNotFoundException: org.jboss.logmanager.LogContextSelector
        at org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy.loadClass(SelfFirstStrategy.java:50)
        at org.codehaus.plexus.classworlds.realm.ClassRealm.unsynchronizedLoadClass(ClassRealm.java:271)
        at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClass(ClassRealm.java:247)
        at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClass(ClassRealm.java:239)
        ... 31 more
To reproduce, call `mvn clean wildfly:run` on the following `pom.xml`:

    <?xml version="1.0" encoding="UTF-8"?>
    <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
        <modelVersion>4.0.0</modelVersion>
    
        <groupId>testing</groupId>
        <artifactId>testing</artifactId>
        <version>1.0.0-SNAPSHOT</version>
    
        <build>
            <plugins>
                <plugin>
                    <groupId>org.wildfly.plugins</groupId>
                    <artifactId>wildfly-maven-plugin</artifactId>
                    <version>1.1.0.Alpha3-SNAPSHOT</version>
                    <configuration>
                        <before-deployment>
                            <commands>
                                <command>
                                    jms-queue add --entries=java:/jms/queue/test --queue-address=Test
                                </command>
                            </commands>
                        </before-deployment>
                        <server-config>standalone-full.xml</server-config>
                    </configuration>
                </plugin>
            </plugins>
        </build>
    </project>

## Fix
I don't know if this is the correct solution, but I've added the `org.jboss.logmanager:jboss-logmanager` dependency. Maybe the proper fix is to remove the usage of the `LogContextSelector` class, but I'm not really sure where it's used. 