### PR TITLE
add management user during wildfly:run

### DIFF
--- a/plugin/src/main/java/org/wildfly/plugin/common/PropertyNames.java
+++ b/plugin/src/main/java/org/wildfly/plugin/common/PropertyNames.java
@@ -85,4 +85,5 @@ public interface PropertyNames {
 
     String SERVER_ARGS = "wildfly.serverArgs";
 
+    String ADD_USER = "wildfly.addUser";
 }

--- a/plugin/src/main/java/org/wildfly/plugin/server/AddUser.java
+++ b/plugin/src/main/java/org/wildfly/plugin/server/AddUser.java
@@ -1,0 +1,10 @@
+package org.wildfly.plugin.server;
+
+import org.apache.maven.plugins.annotations.Parameter;
+
+public class AddUser {
+    @Parameter
+    public String user;
+    @Parameter
+    public String password;
+}


### PR DESCRIPTION
Support management user setup during `wildfly:run`.
Configuration:

    <plugin>
        <groupId>org.wildfly.plugins</groupId>
        <artifactId>wildfly-maven-plugin</artifactId>
        <configuration>
            <add-user>
                <user>admin</user>
                <password>admin</password>
            </add-user>
        </configuration>
    </plugin>

This is an alternative to calling 

    bash target/wildfly-run/wildfly-8.2.0.Final/bin/add-user.sh -u admin -p admin

