### PR TITLE
[WFMP-17] Allow commands to continue being executed if a failure on a previous command has occurred

### DIFF
--- a/plugin/src/main/java/org/wildfly/plugin/cli/ExecuteCommandsMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/cli/ExecuteCommandsMojo.java
@@ -88,7 +88,7 @@ public class ExecuteCommandsMojo extends AbstractServerConnection {
         }
         getLog().debug("Executing commands");
         try (final ManagementClient client = createClient()) {
-            commandExecutor.execute(client, jbossHome, executeCommands);
+            commandExecutor.execute(client, jbossHome, executeCommands.validate(getLog()));
         } catch (IOException e) {
             throw new MojoExecutionException("Could not execute commands.", e);
         }

--- a/plugin/src/main/java/org/wildfly/plugin/deployment/AbstractDeployment.java
+++ b/plugin/src/main/java/org/wildfly/plugin/deployment/AbstractDeployment.java
@@ -139,16 +139,16 @@ abstract class AbstractDeployment extends AbstractServerConnection {
     }
 
     protected final Status executeDeployment(final ManagementClient client, final Deployment deployment, final Path wildflyHome)
-            throws DeploymentExecutionException, DeploymentFailureException, IOException {
+            throws DeploymentExecutionException, MojoFailureException, IOException {
         // Execute before deployment commands
         if (beforeDeployment != null)
-            commandExecutor.execute(client, wildflyHome, beforeDeployment);
+            commandExecutor.execute(client, wildflyHome, beforeDeployment.validate(getLog()));
         // Deploy the deployment
         getLog().debug("Executing deployment");
         final Status status = deployment.execute();
         // Execute after deployment commands
         if (afterDeployment != null)
-            commandExecutor.execute(client, wildflyHome, afterDeployment);
+            commandExecutor.execute(client, wildflyHome, afterDeployment.validate(getLog()));
         return status;
     }
 

--- a/plugin/src/main/java/org/wildfly/plugin/deployment/resource/AddResourceMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/deployment/resource/AddResourceMojo.java
@@ -125,7 +125,7 @@ public class AddResourceMojo extends AbstractServerConnection {
         }
     }
 
-    private void processResources(final ManagementClient client, final Resource... resources) throws IOException {
+    private void processResources(final ManagementClient client, final Resource... resources) throws IOException, MojoFailureException {
         for (Resource resource : resources) {
             if (domain != null) {
                 // Profiles are required when adding resources in domain mode
@@ -137,13 +137,13 @@ public class AddResourceMojo extends AbstractServerConnection {
                     final CompositeOperationBuilder compositeOperationBuilder = CompositeOperationBuilder.create();
                     if (addCompositeResource(profile, client, resource, address, compositeOperationBuilder, true)) {
                         if (resource.hasBeforeAddCommands()) {
-                            commandExecutor.execute(client, jbossHome, resource.getBeforeAdd());
+                            commandExecutor.execute(client, jbossHome, resource.getBeforeAdd().validate(getLog()));
                         }
                         // Execute the add resource operation
                         reportFailure(client.execute(compositeOperationBuilder.build()));
 
                         if (resource.hasAfterAddCommands()) {
-                            commandExecutor.execute(client, jbossHome, resource.getAfterAdd());
+                            commandExecutor.execute(client, jbossHome, resource.getAfterAdd().validate(getLog()));
                         }
                     }
                 }
@@ -151,13 +151,13 @@ public class AddResourceMojo extends AbstractServerConnection {
                 final CompositeOperationBuilder compositeOperationBuilder = CompositeOperationBuilder.create();
                 if (addCompositeResource(null, client, resource, address, compositeOperationBuilder, true)) {
                     if (resource.hasBeforeAddCommands()) {
-                        commandExecutor.execute(client, jbossHome, resource.getBeforeAdd());
+                        commandExecutor.execute(client, jbossHome, resource.getBeforeAdd().validate(getLog()));
                     }
                     // Execute the add resource operation
                     reportFailure(client.execute(compositeOperationBuilder.build()));
 
                     if (resource.hasAfterAddCommands()) {
-                        commandExecutor.execute(client, jbossHome, resource.getAfterAdd());
+                        commandExecutor.execute(client, jbossHome, resource.getAfterAdd().validate(getLog()));
                     }
                 }
             }

--- a/tests/standalone-tests/src/test/java/org/wildfly/plugin/cli/FailOnErrorTest.java
+++ b/tests/standalone-tests/src/test/java/org/wildfly/plugin/cli/FailOnErrorTest.java
@@ -1,0 +1,128 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.plugin.cli;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.apache.maven.plugin.Mojo;
+import org.jboss.as.cli.CommandLineException;
+import org.jboss.dmr.ModelNode;
+import org.junit.Test;
+import org.wildfly.plugin.common.ServerOperations;
+import org.wildfly.plugin.tests.AbstractWildFlyServerMojoTest;
+import org.wildfly.plugin.tests.Environment;
+
+/**
+ * @author <a href="mailto:sven-torben@sven-torben.de">Sven-Torben Janus</a>
+ */
+public class FailOnErrorTest extends AbstractWildFlyServerMojoTest {
+
+    @Test
+    public void testExecuteCommandsFailOnError() throws Exception {
+
+        final Mojo executeCommandsMojo = lookupMojoAndVerify("execute-commands", "execute-commands-failOnError-pom.xml");
+
+        try {
+            executeCommandsMojo.execute();
+            fail("IllegalArgumentException expected.");
+        } catch (IllegalArgumentException e) {
+            assertEquals(CommandLineException.class, e.getCause().getClass());
+        }
+        final ModelNode address = ServerOperations.createAddress("system-property", "propertyFailOnError");
+        final ModelNode op = ServerOperations.createReadAttributeOperation(address, "value");
+        final ModelNode result = executeOperation(op);
+        try {
+            assertEquals("initial value", ServerOperations.readResultAsString(result));
+        } finally {
+            // Remove the system property
+            executeOperation(ServerOperations.createRemoveOperation(address));
+        }
+    }
+
+    @Test
+    public void testExecuteCommandsLocalFailOnError() throws Exception {
+
+        final Mojo executeCommandsMojo = lookupMojoAndVerify("execute-commands", "execute-commands-failOnError-pom.xml");
+        // Set the JBoss home field so commands will be executed in a new process
+        setValue(executeCommandsMojo, "jbossHome", Environment.WILDFLY_HOME.toString());
+
+        try {
+            executeCommandsMojo.execute();
+            fail("IllegalArgumentException expected.");
+        } catch (IllegalStateException ignore) {
+        }
+        final ModelNode address = ServerOperations.createAddress("system-property", "propertyFailOnError");
+        final ModelNode op = ServerOperations.createReadAttributeOperation(address, "value");
+        final ModelNode result = executeOperation(op);
+        try {
+            assertEquals("initial value", ServerOperations.readResultAsString(result));
+        } finally {
+            // Remove the system property
+            executeOperation(ServerOperations.createRemoveOperation(address));
+        }
+    }
+
+    @Test
+    public void testExecuteCommandsContinueOnError() throws Exception {
+
+        final Mojo executeCommandsMojo = lookupMojoAndVerify("execute-commands", "execute-commands-continueOnError-pom.xml");
+
+        executeCommandsMojo.execute();
+
+        // Read the attribute
+        final ModelNode address = ServerOperations.createAddress("system-property", "propertyContinueOnError");
+        final ModelNode op = ServerOperations.createReadAttributeOperation(address, "value");
+        final ModelNode result = executeOperation(op);
+
+        try {
+            assertEquals("continue on error", ServerOperations.readResultAsString(result));
+        } finally {
+            // Clean up the property
+            executeOperation(ServerOperations.createRemoveOperation(address));
+        }
+    }
+
+    @Test
+    public void testExecuteCommandsLocalContinueOnError() throws Exception {
+
+        final Mojo executeCommandsMojo = lookupMojoAndVerify("execute-commands", "execute-commands-continueOnError-pom.xml");
+        // Set the JBoss home field so commands will be executed in a new process
+        setValue(executeCommandsMojo, "jbossHome", Environment.WILDFLY_HOME.toString());
+
+        executeCommandsMojo.execute();
+
+        // Read the attribute
+        final ModelNode address = ServerOperations.createAddress("system-property", "propertyContinueOnError");
+        final ModelNode op = ServerOperations.createReadAttributeOperation(address, "value");
+        final ModelNode result = executeOperation(op);
+
+        try {
+            assertEquals("continue on error", ServerOperations.readResultAsString(result));
+        } finally {
+            // Clean up the property
+            executeOperation(ServerOperations.createRemoveOperation(address));
+        }
+    }
+
+}

--- a/tests/standalone-tests/src/test/resources/test-project/execute-commands-continueOnError-pom.xml
+++ b/tests/standalone-tests/src/test/resources/test-project/execute-commands-continueOnError-pom.xml
@@ -1,6 +1,6 @@
 <!--
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2013, Red Hat, Inc., and individual contributors
+  ~ Copyright 2015, Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags. See the copyright.txt file in the
   ~ distribution for a full listing of individual contributors.
   ~
@@ -34,16 +34,14 @@
                 <artifactId>wildfly-maven-plugin</artifactId>
                 <configuration>
                     <execute-commands>
-                        <batch>true</batch>
-                        <!-- Explicitly set this because the test harness does not properly configure complex configuration
-                        attributes -->
-                        <fail-on-error>true</fail-on-error>
+                        <failOnError>false</failOnError>
                         <commands>
-                            <command>/system-property=org.wildfly.maven.plugin-batch:add(value=true)</command>
+                            <command>/system-property=propertyContinueOnError:add(value="initial value")</command>
+                            <command>/system-property=propertyContinueOnError:add(value="second value")</command>
+                            <command>/system-property=propertyContinueOnError:write-attribute(name=value, value="continue on error")</command>
                         </commands>
                     </execute-commands>
                 </configuration>
-
             </plugin>
         </plugins>
     </build>

--- a/tests/standalone-tests/src/test/resources/test-project/execute-commands-failOnError-pom.xml
+++ b/tests/standalone-tests/src/test/resources/test-project/execute-commands-failOnError-pom.xml
@@ -1,6 +1,6 @@
 <!--
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2013, Red Hat, Inc., and individual contributors
+  ~ Copyright 2015, Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags. See the copyright.txt file in the
   ~ distribution for a full listing of individual contributors.
   ~
@@ -34,16 +34,13 @@
                 <artifactId>wildfly-maven-plugin</artifactId>
                 <configuration>
                     <execute-commands>
-                        <batch>true</batch>
-                        <!-- Explicitly set this because the test harness does not properly configure complex configuration
-                        attributes -->
-                        <fail-on-error>true</fail-on-error>
+                        <failOnError>true</failOnError>
                         <commands>
-                            <command>/system-property=org.wildfly.maven.plugin-batch:add(value=true)</command>
+                            <command>/system-property=propertyFailOnError:add(value="initial value")</command>
+                            <command>/system-property=propertyFailOnError:add(value="fail on error")</command>
                         </commands>
                     </execute-commands>
                 </configuration>
-
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Since a refactor of the way commands are executed PR #47 will no longer cleanly apply. I've updated the concept here to include the new "local" way to execute commands as well.

One key difference is in this PR batch commands are not safely executed nor are script files.

The main reason batch commands aren't safely handled is it seems odd. If a command in a batch fails it seems like everything should be rolled back.

For script files I think the logic for safely handling commands should likely just be in the script itself. Using a try-catch-finally or if-else should work in script files.

Any feedback on this is welcome. I'd love to hear if this will or will not work for the users that would like this feature.

*P.S.* I'm really sorry for the long delay on this. Once I get some feedback I'll cut a release though. 