### PR TITLE
Add --debug Parameter to RunMojo

### DIFF
--- a/plugin/src/main/java/org/wildfly/plugin/common/PropertyNames.java
+++ b/plugin/src/main/java/org/wildfly/plugin/common/PropertyNames.java
@@ -93,4 +93,9 @@ public interface PropertyNames {
 
     String SERVER_ARGS = "wildfly.serverArgs";
 
+    String DEBUG = "wildfly.debug";
+
+    String DEBUG_PORT = "wildfly.debugPort";
+
+    String DEBUG_SUSPEND = "wildfly.debugSuspend";
 }

--- a/plugin/src/main/java/org/wildfly/plugin/server/StartMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/server/StartMojo.java
@@ -219,6 +219,27 @@ public class StartMojo extends AbstractServerConnection {
     @Parameter(alias = "server-type", property = "wildfly.server.type", defaultValue = "STANDALONE")
     private ServerType serverType;
 
+    /**
+     * Enables "debug" mode for server.  Applicable only when running in standalone mode.
+     *
+     * Can be customized using {@code debugPort} and {@code debugSuspend} properties.
+     */
+    @Parameter(property = PropertyNames.DEBUG, defaultValue = "false")
+    private String debug;
+
+    /**
+     * Port for server debug listener.  Only used when {@code debug} is {@code true}.
+     */
+    @Parameter(property = PropertyNames.DEBUG_PORT, defaultValue = "5005")
+    private int debugPort;
+
+
+    /**
+     * Whether or not to suspend and wait for debug listener.  Only used when {@code debug} is {@code true}.
+     */
+    @Parameter(property = PropertyNames.DEBUG_SUSPEND, defaultValue = "false")
+    private String debugSuspend;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         final Log log = getLog();
@@ -297,6 +318,10 @@ public class StartMojo extends AbstractServerConnection {
 
         if (serverArgs != null) {
             commandBuilder.addServerArguments(serverArgs);
+        }
+
+        if (Boolean.parseBoolean(debug)) {
+            commandBuilder.setDebug(Boolean.parseBoolean(debugSuspend), debugPort);
         }
 
         // Print some server information

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -47,6 +47,16 @@
         <wildfly.test.deployment.name>test.war</wildfly.test.deployment.name>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>com.sun</groupId>
+            <artifactId>tools</artifactId>
+            <version>${maven.compiler.target}}</version>
+            <scope>system</scope>
+            <systemPath>${java.home}/../lib/tools.jar</systemPath>
+        </dependency>
+    </dependencies>
+
     <build>
         <plugins>
             <plugin>

--- a/tests/shared/src/test/resources/test-project/start-with-debug-pom.xml
+++ b/tests/shared/src/test/resources/test-project/start-with-debug-pom.xml
@@ -1,0 +1,43 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2015, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>testing</groupId>
+    <artifactId>testing</artifactId>
+    <packaging>war</packaging>
+    <version>0.1.0-SNAPSHOT</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <configuration>
+                    <debug>true</debug>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/tests/shared/src/test/resources/test-project/start-with-debug-port-pom.xml
+++ b/tests/shared/src/test/resources/test-project/start-with-debug-port-pom.xml
@@ -1,0 +1,44 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2015, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>testing</groupId>
+    <artifactId>testing</artifactId>
+    <packaging>war</packaging>
+    <version>0.1.0-SNAPSHOT</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <configuration>
+                    <debug>true</debug>
+                    <debugPort>1337</debugPort>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>


### PR DESCRIPTION
I found a need for the `--debug` parameter while using this plugin, and after fiddling around with some scripts and what not, just decided to add it.  A couple of notes:

* I chose to separate the core functionality from the test cases (2 commits) since the test cases require a system dependency on the tools.jar.  I wasn't sure if this was a dependency you wanted to introduce, as it will require all contributors to have the JDK installed.  Seems reasonable to me, but I segregated them just in case.  Also, if you know of a way to check whether a server is listening for debuggers that does not use the JDI, it might knock out that dependency.
* It looks like you use several of the same configuration settings from `StartMojo` on `RunMojo`.  I'd be happy to make corresponding changes to `RunMojo` to keep the two in sync.  Just let me know and I'll send another PR your way!