### PR TITLE
Prevent NPE if classifier of dependency is null

### DIFF
--- a/plugin/src/main/java/org/wildfly/plugin/deployment/AbstractDeployment.java
+++ b/plugin/src/main/java/org/wildfly/plugin/deployment/AbstractDeployment.java
@@ -232,24 +232,4 @@ abstract class AbstractDeployment extends AbstractServerConnection {
             throw new DeploymentFailureException("Server is running in standalone mode, but server groups have been defined.");
         }
     }
-
-
-    /**
-     * Checks if the given strings are equal. {@code null} ist handles as empty string.
-     * @param first the first value
-     * @param second the second value
-     * @return {@code true} if the given strings are equal.
-     */
-    protected boolean equalsNullSafe(String first, String second) {
-        return trimNullSafe(first).equals(trimNullSafe(second));
-    }
-
-    /**
-     * Trims the given string null-safe. {@code null} is replaced with ""
-     * @param value the value to be trimmed
-     * @return the trimmed string.
-     */
-    protected String trimNullSafe(String value) {
-        return value == null ? "" : value.trim();
-    }
 }

--- a/plugin/src/main/java/org/wildfly/plugin/deployment/AbstractDeployment.java
+++ b/plugin/src/main/java/org/wildfly/plugin/deployment/AbstractDeployment.java
@@ -232,4 +232,24 @@ abstract class AbstractDeployment extends AbstractServerConnection {
             throw new DeploymentFailureException("Server is running in standalone mode, but server groups have been defined.");
         }
     }
+
+
+    /**
+     * Checks if the given strings are equal. {@code null} ist handles as empty string.
+     * @param first the first value
+     * @param second the second value
+     * @return {@code true} if the given strings are equal.
+     */
+    protected boolean equalsNullSafe(String first, String second) {
+        return trimNullSafe(first).equals(trimNullSafe(second));
+    }
+
+    /**
+     * Trims the given string null-safe. {@code null} is replaced with ""
+     * @param value the value to be trimmed
+     * @return the trimmed string.
+     */
+    protected String trimNullSafe(String value) {
+        return value == null ? "" : value.trim();
+    }
 }

--- a/plugin/src/main/java/org/wildfly/plugin/deployment/DeployArtifactMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/deployment/DeployArtifactMojo.java
@@ -88,9 +88,9 @@ public final class DeployArtifactMojo extends AbstractDeployment {
         final Set<Artifact> dependencies = project.getDependencyArtifacts();
         Artifact artifact = null;
         for (final Artifact a : dependencies) {
-            if (a.getArtifactId().equals(artifactId) &&
-                    a.getGroupId().equals(groupId) &&
-                    a.getClassifier().equals(classifier == null ? "" : classifier)) {
+            if (equalsNullSafe(a.getArtifactId(), artifactId) &&
+                equalsNullSafe(a.getGroupId(), groupId) &&
+                equalsNullSafe(a.getClassifier(), classifier)) {
                 artifact = a;
                 break;
             }

--- a/plugin/src/main/java/org/wildfly/plugin/deployment/DeployArtifactMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/deployment/DeployArtifactMojo.java
@@ -23,6 +23,7 @@
 package org.wildfly.plugin.deployment;
 
 import java.io.File;
+import java.util.Objects;
 import java.util.Set;
 
 import org.apache.maven.artifact.Artifact;
@@ -88,9 +89,9 @@ public final class DeployArtifactMojo extends AbstractDeployment {
         final Set<Artifact> dependencies = project.getDependencyArtifacts();
         Artifact artifact = null;
         for (final Artifact a : dependencies) {
-            if (equalsNullSafe(a.getArtifactId(), artifactId) &&
-                equalsNullSafe(a.getGroupId(), groupId) &&
-                equalsNullSafe(a.getClassifier(), classifier)) {
+            if (Objects.equals(a.getArtifactId(), artifactId) &&
+                Objects.equals(a.getGroupId(), groupId) &&
+                Objects.equals(a.getClassifier(), classifier)) {
                 artifact = a;
                 break;
             }

--- a/plugin/src/main/java/org/wildfly/plugin/deployment/UndeployArtifactMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/deployment/UndeployArtifactMojo.java
@@ -23,6 +23,7 @@
 package org.wildfly.plugin.deployment;
 
 import java.io.File;
+import java.util.Objects;
 import java.util.Set;
 
 import org.apache.maven.artifact.Artifact;
@@ -85,9 +86,9 @@ public final class UndeployArtifactMojo extends AbstractDeployment {
         final Set<Artifact> dependencies = project.getDependencyArtifacts();
         Artifact artifact = null;
         for (final Artifact a : dependencies) {
-            if (equalsNullSafe(a.getArtifactId(), artifactId) &&
-                equalsNullSafe(a.getGroupId(), groupId) &&
-                equalsNullSafe(a.getClassifier(), classifier)) {
+            if (Objects.equals(a.getArtifactId(), artifactId) &&
+                Objects.equals(a.getGroupId(), groupId) &&
+                Objects.equals(a.getClassifier(), classifier)) {
                 artifact = a;
                 break;
             }

--- a/plugin/src/main/java/org/wildfly/plugin/deployment/UndeployArtifactMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/deployment/UndeployArtifactMojo.java
@@ -85,9 +85,9 @@ public final class UndeployArtifactMojo extends AbstractDeployment {
         final Set<Artifact> dependencies = project.getDependencyArtifacts();
         Artifact artifact = null;
         for (final Artifact a : dependencies) {
-            if (a.getArtifactId().equals(artifactId) &&
-                    a.getGroupId().equals(groupId) &&
-                    a.getClassifier().equals(classifier == null ? "" : classifier)) {
+            if (equalsNullSafe(a.getArtifactId(), artifactId) &&
+                equalsNullSafe(a.getGroupId(), groupId) &&
+                equalsNullSafe(a.getClassifier(), classifier)) {
                 artifact = a;
                 break;
             }

--- a/tests/standalone-tests/src/test/java/org/wildfly/plugin/deployment/ArtifactDeploymentTest.java
+++ b/tests/standalone-tests/src/test/java/org/wildfly/plugin/deployment/ArtifactDeploymentTest.java
@@ -52,7 +52,7 @@ public class ArtifactDeploymentTest extends AbstractWildFlyServerMojoTest {
     @Test
     public void testDeploy() throws Exception {
         final DeployArtifactMojo mojo = lookupMojoAndVerify("deploy-artifact", "deploy-artifact-pom.xml");
-        testDeploy(mojo, "");
+        testDeploy(mojo, null);
     }
 
     @Test
@@ -64,7 +64,7 @@ public class ArtifactDeploymentTest extends AbstractWildFlyServerMojoTest {
     @Test
     public void testUndeploy() throws Exception {
         final UndeployArtifactMojo mojo = lookupMojoAndVerify("undeploy-artifact", "deploy-artifact-pom.xml");
-        testUndeploy(mojo, "");
+        testUndeploy(mojo, null);
     }
 
     @Test


### PR DESCRIPTION
If the classifier of a project dependency is not defined it is null (maven 3.3.3).

This fix prevents a NPE during the verification of the mojo.