### PR TITLE
[WFMP-47] Add tests for core module

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -34,6 +34,12 @@
         Utilities a plugin can use to interact with WildFly container.
     </description>
 
+    <properties>
+        <version.org.jboss.shrinkwrap.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap.shrinkwrap>
+
+        <jboss.home>${project.build.directory}${file.separator}wildfly-${version.org.wildfly.dist}</jboss.home>
+    </properties>
+
     <licenses>
         <license>
             <name>Apache License Version 2.0</name>
@@ -73,5 +79,74 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.jboss.shrinkwrap</groupId>
+            <artifactId>shrinkwrap-api</artifactId>
+            <version>${version.org.jboss.shrinkwrap.shrinkwrap}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.shrinkwrap</groupId>
+            <artifactId>shrinkwrap-impl-base</artifactId>
+            <version>${version.org.jboss.shrinkwrap.shrinkwrap}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack-wildfly</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.wildfly</groupId>
+                                    <artifactId>wildfly-dist</artifactId>
+                                    <version>${version.org.wildfly.dist}</version>
+                                    <type>zip</type>
+                                    <!-- overwrite to clean any previous deployments -->
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${project.build.directory}</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemProperties>
+                        <test.deployment.dir>${project.build.testOutputDirectory}</test.deployment.dir>
+                    </systemProperties>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <redirectTestOutputToFile>${maven.test.redirectTestOutputToFile}</redirectTestOutputToFile>
+                    <systemPropertyVariables>
+                        <jboss.home>${jboss.home}</jboss.home>
+                    </systemPropertyVariables>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/core/src/main/java/org/wildfly/plugin/core/Assertions.java
+++ b/core/src/main/java/org/wildfly/plugin/core/Assertions.java
@@ -19,30 +19,62 @@
 
 package org.wildfly.plugin.core;
 
-import java.util.Arrays;
+import java.util.Collection;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
 class Assertions {
+
     /**
-     * Checks if the parameter is {@code null} and throws an {@link IllegalArgumentException} it is.
+     * Checks if the parameter is {@code null} and throws an {@link IllegalArgumentException} if it is.
      *
-     * @param object the object to check
-     * @param name   the name of the parameter
-     * @param <T>    the parameter type
+     * @param value the value to check
+     * @param name  the name of the parameter
+     * @param <T>   the parameter type
      *
      * @return the parameter value
      *
      * @throws IllegalArgumentException if the object representing the parameter is {@code null}
      */
-    static <T> T requiresNotNullParameter(final T object, final String name) throws IllegalArgumentException {
-        if (object == null) {
-            final IllegalArgumentException e = new IllegalArgumentException(String.format("Parameter %s is required and cannot be null.", name));
-            final StackTraceElement[] st = e.getStackTrace();
-            e.setStackTrace(Arrays.copyOfRange(st, 1, st.length));
-            throw e;
+    static <T> T requiresNotNullParameter(final T value, final String name) throws IllegalArgumentException {
+        if (value == null) {
+            throw new IllegalArgumentException(String.format("Parameter %s is required and cannot be null.", name));
         }
-        return object;
+        return value;
+    }
+
+    /**
+     * Checks if the parameter is {@code null} or empty and throws an {@link IllegalArgumentException} if it is.
+     *
+     * @param value the value to check
+     * @param name  the name of the parameter
+     *
+     * @return the parameter value
+     *
+     * @throws IllegalArgumentException if the object representing the parameter is {@code null}
+     */
+    static String requiresNotNullOrNotEmptyParameter(final String value, final String name) throws IllegalArgumentException {
+        if (value == null || value.trim().isEmpty()) {
+            throw new IllegalArgumentException(String.format("Parameter %s is required and cannot be null or empty.", name));
+        }
+        return value;
+    }
+
+    /**
+     * Checks if the parameter is {@code null} or empty and throws an {@link IllegalArgumentException} if it is.
+     *
+     * @param value the value to check
+     * @param name  the name of the parameter
+     *
+     * @return the parameter value
+     *
+     * @throws IllegalArgumentException if the object representing the parameter is {@code null}
+     */
+    static <E, T extends Collection<E>> T requiresNotNullOrNotEmptyParameter(final T value, final String name) throws IllegalArgumentException {
+        if (value == null || value.isEmpty()) {
+            throw new IllegalArgumentException(String.format("Parameter %s is required and cannot be null or empty.", name));
+        }
+        return value;
     }
 }

--- a/core/src/main/java/org/wildfly/plugin/core/Deployment.java
+++ b/core/src/main/java/org/wildfly/plugin/core/Deployment.java
@@ -72,7 +72,7 @@ public class Deployment implements DeploymentDescription, Comparable<Deployment>
      */
     private Deployment(final InputStream content, final String name) {
         this.content = DeploymentContent.of(content);
-        this.name = Assertions.requiresNotNullParameter(name, "name");
+        this.name = Assertions.requiresNotNullOrNotEmptyParameter(name, "name");
         serverGroups = new LinkedHashSet<>();
     }
 
@@ -116,7 +116,7 @@ public class Deployment implements DeploymentDescription, Comparable<Deployment>
      */
     public static Deployment of(final InputStream content, final String name) {
         return new Deployment(Assertions.requiresNotNullParameter(content, "content"),
-                Assertions.requiresNotNullParameter(name, "name"));
+                Assertions.requiresNotNullOrNotEmptyParameter(name, "name"));
     }
 
     /**
@@ -125,6 +125,9 @@ public class Deployment implements DeploymentDescription, Comparable<Deployment>
      * @param serverGroup the server group to add
      *
      * @return this deployment
+     *
+     * @see #addServerGroups(Collection)
+     * @see #addServerGroups(String...)
      */
     public Deployment addServerGroup(final String serverGroup) {
         serverGroups.add(serverGroup);
@@ -137,6 +140,9 @@ public class Deployment implements DeploymentDescription, Comparable<Deployment>
      * @param serverGroups the server groups to add
      *
      * @return this deployment
+     *
+     * @see #addServerGroup(String)
+     * @see #addServerGroups(Collection)
      */
     public Deployment addServerGroups(final String... serverGroups) {
         return addServerGroups(Arrays.asList(serverGroups));
@@ -148,6 +154,9 @@ public class Deployment implements DeploymentDescription, Comparable<Deployment>
      * @param serverGroups the server groups to add
      *
      * @return this deployment
+     *
+     * @see #addServerGroup(String)
+     * @see #addServerGroups(String...)
      */
     public Deployment addServerGroups(final Collection<String> serverGroups) {
         this.serverGroups.addAll(serverGroups);

--- a/core/src/main/java/org/wildfly/plugin/core/DeploymentContent.java
+++ b/core/src/main/java/org/wildfly/plugin/core/DeploymentContent.java
@@ -83,7 +83,8 @@ abstract class DeploymentContent {
                     contentItem.get(PATH).set(content.toAbsolutePath().toString());
                     contentItem.get("archive").set(false);
                 } else {
-                    contentItem.get(ClientConstants.INPUT_STREAM_INDEX).set(0);
+                    // The index is 0 based so use the input stream count before adding the input stream
+                    contentItem.get(ClientConstants.INPUT_STREAM_INDEX).set(builder.getInputStreamCount());
                     builder.addFileAsAttachment(content.toFile());
                 }
             }
@@ -116,7 +117,8 @@ abstract class DeploymentContent {
                 copiedContent.reset();
                 final ModelNode contentNode = op.get(CONTENT);
                 final ModelNode contentItem = contentNode.get(0);
-                contentItem.get(ClientConstants.INPUT_STREAM_INDEX).set(0);
+                // The index is 0 based so use the input stream count before adding the input stream
+                contentItem.get(ClientConstants.INPUT_STREAM_INDEX).set(builder.getInputStreamCount());
                 builder.addInputStream(copiedContent);
             }
 

--- a/core/src/main/java/org/wildfly/plugin/core/DeploymentManager.java
+++ b/core/src/main/java/org/wildfly/plugin/core/DeploymentManager.java
@@ -31,6 +31,11 @@ import org.jboss.as.controller.client.ModelControllerClient;
  * The {@linkplain DeploymentResult#asModelNode() server result} for each deployment operation will be the result of a
  * composite operation.
  * </p>
+ * <p>
+ * If the server is a managed domain {@linkplain DeploymentDescription#getServerGroups() server groups} are required. If
+ * the server is a standalone server no server groups are allowed to be define. A failed {@link DeploymentResult}
+ * will be returned if the server groups are empty for a managed domain or populated for a standalone server.
+ * </p>
  *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
@@ -249,25 +254,57 @@ public interface DeploymentManager {
     Set<String> getDeploymentNames() throws IOException;
 
     /**
-     * Checks if the deployment is on the server.
+     * Checks if the deployment content is on the server.
      *
      * @param name the name of the deployment
      *
-     * @return {@code true} if the deployment exists otherwise {@code false}
+     * @return {@code true} if the deployment content exists otherwise {@code false}
      *
      * @throws IOException if a failure occurs communicating with the server
      */
     boolean hasDeployment(String name) throws IOException;
 
     /**
-     * Checks if the deployment is on the server.
+     * Checks if the deployment content is on the server.
      *
      * @param name        the name of the deployment
      * @param serverGroup the server group to check for the deployment on
      *
-     * @return {@code true} if the deployment exists otherwise {@code false}
+     * @return {@code true} if the deployment content exists otherwise {@code false}
      */
     boolean hasDeployment(String name, String serverGroup) throws IOException;
+
+    /**
+     * Checks if the deployment has been deployed to the runtime. The deployment must already exist on the server.
+     * <p>
+     * If a deployment is enabled it has been deployed to the runtime. Otherwise the deployment has <em>not</em> been
+     * deployed to the runtime.
+     * </p>
+     *
+     * @param name the name of the deployment
+     *
+     * @return {@code true} if the deployment content exists and is enabled otherwise {@code false}
+     *
+     * @throws IOException if a failure occurs communicating with the server
+     * @see #isEnabled(String, String) for managed domain deployments
+     */
+    boolean isEnabled(String name) throws IOException;
+
+    /**
+     * Checks if the deployment has been deployed to the runtime. The deployment must already exist on the server.
+     * <p>
+     * If a deployment is enabled it has been deployed to the runtime. Otherwise the deployment has <em>not</em> been
+     * deployed to the runtime.
+     * </p>
+     *
+     * @param name        the name of the deployment
+     * @param serverGroup the server group to check for the deployment on
+     *
+     * @return {@code true} if the deployment content exists and is enabled otherwise {@code false}
+     *
+     * @see #isEnabled(String) for standalone deployments
+     */
+    boolean isEnabled(String name, String serverGroup) throws IOException;
 
     /**
      * A factory to create a new deployment manager
@@ -276,6 +313,10 @@ public interface DeploymentManager {
 
         /**
          * Creates a new deployment manager.
+         * <p>
+         * The client will not be {@linkplain ModelControllerClient#close() closed} by the {@link DeploymentManager}.
+         * The user is responsible for {@linkplain ModelControllerClient#close() closing} the client.
+         * </p>
          *
          * @param client the client used to communicate with the server
          *

--- a/core/src/main/java/org/wildfly/plugin/core/DeploymentOperations.java
+++ b/core/src/main/java/org/wildfly/plugin/core/DeploymentOperations.java
@@ -57,7 +57,7 @@ import org.jboss.dmr.ModelType;
  */
 @SuppressWarnings({"unused", "StaticMethodOnlyUsedInOneClass", "WeakerAccess"})
 public class DeploymentOperations {
-    private static final String ENABLED = "enabled";
+    static final String ENABLED = "enabled";
     static final ModelNode EMPTY_ADDRESS = new ModelNode().setEmptyList();
 
     static {
@@ -131,7 +131,7 @@ public class DeploymentOperations {
      * @see #createDeployOperation(Set)
      */
     public static Operation createAddDeploymentOperation(final Set<Deployment> deployments) {
-        Assertions.requiresNotNullParameter(deployments, "deployments");
+        Assertions.requiresNotNullOrNotEmptyParameter(deployments, "deployments");
         final CompositeOperationBuilder builder = CompositeOperationBuilder.create(true);
         for (Deployment deployment : deployments) {
             addDeploymentOperationStep(builder, deployment);
@@ -161,7 +161,7 @@ public class DeploymentOperations {
      * @return the deploy operation
      */
     public static Operation createDeployOperation(final Set<DeploymentDescription> deployments) {
-        Assertions.requiresNotNullParameter(deployments, "deployments");
+        Assertions.requiresNotNullOrNotEmptyParameter(deployments, "deployments");
         final CompositeOperationBuilder builder = CompositeOperationBuilder.create(true);
         for (DeploymentDescription deployment : deployments) {
             addDeployOperationStep(builder, deployment);
@@ -193,7 +193,7 @@ public class DeploymentOperations {
      * @return the deploy operation
      */
     public static Operation createReplaceOperation(final Set<Deployment> deployments) {
-        Assertions.requiresNotNullParameter(deployments, "deployments");
+        Assertions.requiresNotNullOrNotEmptyParameter(deployments, "deployments");
         final CompositeOperationBuilder builder = CompositeOperationBuilder.create(true);
         for (Deployment deployment : deployments) {
             addReplaceOperationSteps(builder, deployment);
@@ -231,7 +231,7 @@ public class DeploymentOperations {
      * @return the redeploy operation
      */
     public static Operation createRedeployOperation(final Set<DeploymentDescription> deployments) {
-        Assertions.requiresNotNullParameter(deployments, "deployments");
+        Assertions.requiresNotNullOrNotEmptyParameter(deployments, "deployments");
         final CompositeOperationBuilder builder = CompositeOperationBuilder.create(true);
         for (DeploymentDescription deployment : deployments) {
             addRedeployOperationStep(builder, deployment);
@@ -245,6 +245,10 @@ public class DeploymentOperations {
      * If the {@link UndeployDescription#isRemoveContent()} returns {@code true} the content will also be removed from
      * the content repository. Otherwise the content will remain on the server and only the {@code undeploy} operation
      * will be executed.
+     * </p>
+     * <p>
+     * Note that the {@link UndeployDescription#isFailOnMissing() failOnMissing} is ignored and the operation will fail
+     * if any deployments being undeployed are missing.
      * </p>
      *
      * @param undeployDescription the description used to crate the operation
@@ -265,13 +269,17 @@ public class DeploymentOperations {
      * the content repository. Otherwise the content will remain on the server and only the {@code undeploy} operation
      * will be executed.
      * </p>
+     * <p>
+     * Note that the {@link UndeployDescription#isFailOnMissing() failOnMissing} is ignored and the operation will fail
+     * if any deployments being undeployed are missing.
+     * </p>
      *
      * @param undeployDescriptions the set of descriptions used to crate the operation
      *
      * @return the undeploy operation
      */
     public static Operation createUndeployOperation(final Set<UndeployDescription> undeployDescriptions) {
-        Assertions.requiresNotNullParameter(undeployDescriptions, "undeployDescriptions");
+        Assertions.requiresNotNullOrNotEmptyParameter(undeployDescriptions, "undeployDescriptions");
         final CompositeOperationBuilder builder = CompositeOperationBuilder.create(true);
         for (UndeployDescription undeployDescription : undeployDescriptions) {
             addUndeployOperationStep(builder, undeployDescription);

--- a/core/src/main/java/org/wildfly/plugin/core/DeploymentResult.java
+++ b/core/src/main/java/org/wildfly/plugin/core/DeploymentResult.java
@@ -55,7 +55,7 @@ public class DeploymentResult {
         } else {
             failureMessage = Operations.getFailureDescription(result).asString();
         }
-        this.result = (successful ? Operations.readResult(result).clone() : new ModelNode());
+        this.result = result.clone();
         this.result.protect();
     }
 
@@ -78,10 +78,7 @@ public class DeploymentResult {
      * @param args   the arguments for the format pattern
      */
     DeploymentResult(final String format, final Object... args) {
-        successful = false;
-        this.failureMessage = String.format(format, args);
-        result = new ModelNode();
-        result.protect();
+        this(String.format(format, args));
     }
 
     /**

--- a/core/src/main/java/org/wildfly/plugin/core/ServerProcess.java
+++ b/core/src/main/java/org/wildfly/plugin/core/ServerProcess.java
@@ -165,6 +165,7 @@ public class ServerProcess extends Process {
      *
      * @return the consumer thread or {@code null} if the processes inherits the streams from the parent process
      */
+    @SuppressWarnings("unused")
     public Thread getConsoleConsumer() {
         return consoleConsumer;
     }
@@ -174,6 +175,7 @@ public class ServerProcess extends Process {
      *
      * @return {@code true} if the streams are inherited from the parent process, otherwise {@code false}
      */
+    @SuppressWarnings({"unused", "WeakerAccess"})
     public boolean isInheritedStreams() {
         return inherited;
     }
@@ -198,7 +200,8 @@ public class ServerProcess extends Process {
 
         @Override
         public void run() {
-            byte[] buffer = new byte[64];
+            @SuppressWarnings("MagicNumber")
+            final byte[] buffer = new byte[64];
             try {
                 int len;
                 while ((len = in.read(buffer)) != -1) {

--- a/core/src/main/java/org/wildfly/plugin/core/SimpleDeploymentDescription.java
+++ b/core/src/main/java/org/wildfly/plugin/core/SimpleDeploymentDescription.java
@@ -50,7 +50,7 @@ public class SimpleDeploymentDescription implements DeploymentDescription, Compa
      * @return the deployment description
      */
     public static SimpleDeploymentDescription of(final String name) {
-        return new SimpleDeploymentDescription(Assertions.requiresNotNullParameter(name, "name"));
+        return new SimpleDeploymentDescription(Assertions.requiresNotNullOrNotEmptyParameter(name, "name"));
     }
 
     /**

--- a/core/src/main/java/org/wildfly/plugin/core/UndeployDescription.java
+++ b/core/src/main/java/org/wildfly/plugin/core/UndeployDescription.java
@@ -62,7 +62,7 @@ public class UndeployDescription implements DeploymentDescription, Comparable<Un
      * @return the description
      */
     public static UndeployDescription of(final String name) {
-        return new UndeployDescription(Assertions.requiresNotNullParameter(name, "name"));
+        return new UndeployDescription(Assertions.requiresNotNullOrNotEmptyParameter(name, "name"));
     }
 
     /**
@@ -199,6 +199,7 @@ public class UndeployDescription implements DeploymentDescription, Comparable<Un
         result.append('(');
         result.append("name=").append(name);
         result.append(", failOnMissing=").append(failOnMissing);
+        result.append(", removeContent=").append(removeContent);
         if (!serverGroups.isEmpty()) {
             result.append(", serverGroups=").append(serverGroups);
         }

--- a/core/src/test/java/org/wildfly/plugin/core/AbstractDeploymentManagerTest.java
+++ b/core/src/test/java/org/wildfly/plugin/core/AbstractDeploymentManagerTest.java
@@ -1,0 +1,669 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2016 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.plugin.core;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.helpers.ClientConstants;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.wildfly.plugin.core.common.Simple;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@SuppressWarnings("WeakerAccess")
+abstract class AbstractDeploymentManagerTest {
+
+    private static final char[] hexChars = {
+            '0', '1', '2', '3', '4', '5', '6', '7',
+            '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'
+    };
+
+    protected DeploymentManager deploymentManager;
+
+    @Before
+    public void setup() throws UnknownHostException {
+        deploymentManager = DeploymentManager.Factory.create(getClient());
+    }
+
+    @After
+    public void undeployAll() throws IOException {
+        final Set<UndeployDescription> deployments = new HashSet<>();
+        for (DeploymentDescription deployment : deploymentManager.getDeployments()) {
+            deployments.add(UndeployDescription.of(deployment));
+        }
+        if (!deployments.isEmpty()) {
+            deploymentManager.undeploy(deployments).assertSuccess();
+        }
+    }
+
+    @Test
+    public void testDeploy() throws Exception {
+        final String deploymentName = "test-deploy.war";
+        final Deployment deployment = createDefaultDeployment(deploymentName);
+        deployForSuccess(deployment);
+        assertDeploymentEnabled(deployment);
+
+        // Expect a failure when trying to deploy the same content
+        assertFailed(deploymentManager.deploy(deployment));
+    }
+
+    @Test
+    public void testDeployMulti() throws Exception {
+        final Deployment deployment1 = createDefaultDeployment("test-deploy-1.war");
+        final Deployment deployment2 = createDefaultDeployment("test-deploy-2.war");
+        final Set<Deployment> deployments = newSet(deployment1, deployment2);
+        deployForSuccess(deployments);
+        assertDeploymentEnabled(deployment1);
+        assertDeploymentEnabled(deployment2);
+
+        // Expect a failure when trying to deploy the same content
+        assertFailed(deploymentManager.deploy(deployments));
+        // Deployments should still exist and be enabled
+        assertDeploymentExists(deployment1, true);
+        assertDeploymentExists(deployment2, true);
+    }
+
+    @Test
+    public void testForceDeploy() throws Exception {
+        final String deploymentName = "test-deploy.war";
+        final Deployment deployment = createDefaultDeployment(deploymentName);
+        DeployResult deployResult = deployForSuccess(deployment, true);
+
+        // Get the current hash
+        final byte[] hash = deployResult.hash;
+        long lastEnabledTime = deployResult.enabledTime;
+
+        // Force deploy the content and ensure the hash is the same
+        deployResult = deployForSuccess(deployment, true);
+        assertDeploymentEnabled(deployment);
+
+        byte[] currentHash = deployResult.hash;
+        long currentLastEnabledTime = deployResult.enabledTime;
+        // Compare the original hash and the new hash, they should be equal as the content is exactly the same. However
+        // the timestamps should not be equal as the content should have been replaced and therefore undeployed, then
+        // redeployed.
+        Assert.assertArrayEquals(
+                String.format("Expected hash to be equal: %nExpected: %s%nFound: %s%n", bytesToHexString(hash), bytesToHexString(currentHash)),
+                hash, currentHash);
+        Assert.assertNotEquals("Last enabled times should not match.", lastEnabledTime, currentLastEnabledTime);
+
+        // Create a new deployment, add new content and force deploy it which should result in a new hash and timestamp
+        final WebArchive archive = createDefaultArchive(deploymentName)
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+        final Deployment changedDeployment = createDeployment(archive);
+        deployResult = deployForSuccess(changedDeployment, true);
+        assertDeploymentEnabled(changedDeployment);
+
+        currentHash = deployResult.hash;
+        lastEnabledTime = currentLastEnabledTime;
+        currentLastEnabledTime = deployResult.enabledTime;
+
+        // In this case we've added some new content to the deployment. The hashes should not match and once again the
+        // timestamps should be different.
+        Assert.assertFalse(
+                String.format("Expected hash to be equal: %nExpected: %s%nFound: %s%n", bytesToHexString(hash), bytesToHexString(currentHash)),
+                Arrays.equals(hash, currentHash));
+        Assert.assertNotEquals("Last enabled times should not match.", lastEnabledTime, currentLastEnabledTime);
+
+    }
+
+    @Test
+    public void testForceDeployMulti() throws Exception {
+        final Deployment deployment1 = createDefaultDeployment("test-deploy-1.war");
+        final Deployment deployment2 = createDefaultDeployment("test-deploy-2.war");
+        final Set<Deployment> deployments = newSet(deployment1, deployment2);
+        final Map<Deployment, DeployResult> first = deployForSuccess(deployments, true);
+
+        // Force deploy the content and ensure the hash is the same
+        final Set<Deployment> deployments2 = newSet(deployment1, deployment2);
+        final Map<Deployment, DeployResult> second = deployForSuccess(deployments2, true);
+
+        Assert.assertEquals(first.size(), second.size());
+        Assert.assertTrue(first.keySet().containsAll(second.keySet()));
+
+        // Skip time checks on domain until WFCORE-1667 is fixed
+        final boolean checkTime = !ServerHelper.isDomainServer(getClient());
+        // Get the current hash
+        for (Deployment deployment : deployments) {
+            final byte[] hash = first.get(deployment).hash;
+            final long lastEnabledTime = first.get(deployment).enabledTime;
+
+            final byte[] currentHash = second.get(deployment).hash;
+            final long currentLastEnabledTime = second.get(deployment).enabledTime;
+            // Compare the original hash and the new hash, they should be equal as the content is exactly the same. However
+            // the timestamps should not be equal as the content should have been replaced and therefore undeployed, then
+            // redeployed.
+            Assert.assertArrayEquals(
+                    String.format("Expected hash to be equal: %nExpected: %s%nFound: %s%n", bytesToHexString(hash), bytesToHexString(currentHash)),
+                    hash, currentHash);
+            if (checkTime) {
+                Assert.assertNotEquals("Last enabled times should not match", lastEnabledTime, currentLastEnabledTime);
+            }
+        }
+    }
+
+    @Test
+    public void testDeployToRuntime() throws Exception {
+        final String deploymentName = "test-runtime-deploy.war";
+        final Deployment deployment = createDefaultDeployment(deploymentName)
+                .setEnabled(false);
+
+        deployForSuccess(deployment);
+        // The content should be disable, i.e. not deployed to the runtime
+        assertDeploymentDisabled(deployment);
+
+        // Deploy the content to the runtime, this should result in the enabled field resulting in true
+        assertSuccess(deploymentManager.deployToRuntime(deployment));
+        // The content should now be enabled, i.e. deployed to runtime
+        assertDeploymentEnabled(deployment);
+    }
+
+    @Test
+    public void testDeployToRuntimeMulti() throws Exception {
+        final Deployment deployment1 = createDefaultDeployment("test-runtime-deploy-1.war")
+                .setEnabled(false);
+        final Deployment deployment2 = createDefaultDeployment("test-runtime-deploy-2.war")
+                .setEnabled(false);
+        final Deployment deployment3 = createDefaultDeployment("test-runtime-deploy-3.war")
+                .setEnabled(true);
+
+        deployForSuccess(newSet(deployment1, deployment2, deployment3));
+        // The content should be disable, i.e. not deployed to the runtime
+        assertDeploymentDisabled(deployment1);
+        assertDeploymentDisabled(deployment2);
+        // This third deployment should be enabled
+        assertDeploymentEnabled(deployment3);
+
+        // Deploy the content to the runtime, this should result in the enabled field resulting in true
+        assertSuccess(deploymentManager.deployToRuntime(newSet((DeploymentDescription) deployment1, deployment2, deployment3)));
+        // The content should now be enabled, i.e. deployed to runtime
+        assertDeploymentEnabled(deployment1);
+        assertDeploymentEnabled(deployment2);
+        assertDeploymentEnabled(deployment3);
+    }
+
+    @Test
+    public void testRedeploy() throws Exception {
+        final String deploymentName = "test-redeploy.war";
+        final Deployment deployment = createDefaultDeployment(deploymentName);
+
+        // Redeploy should fail as the deployment should not exist
+        assertFailed(deploymentManager.redeploy(deployment));
+
+        // Deploy the content, the redeploy for a successful redeploy
+        final DeployResult deployResult = deployForSuccess(deployment);
+        final DeployResult currentDeployResult = redeployForSuccess(deployment);
+        // Compare the original hash and the new hash, they should be equal as the content is exactly the same. However
+        // the timestamps should not be equal as the content should have been replaced and therefore undeployed, then
+        // redeployed.
+        Assert.assertArrayEquals(
+                String.format("Expected hash to be equal: %nExpected: %s%nFound: %s%n", bytesToHexString(deployResult.hash),
+                        bytesToHexString(currentDeployResult.hash)),
+                deployResult.hash, currentDeployResult.hash);
+        Assert.assertNotEquals("Last enabled times should not match.", deployResult.enabledTime, currentDeployResult.enabledTime);
+    }
+
+    @Test
+    public void testRedeployMulti() throws Exception {
+        final Deployment deployment1 = createDefaultDeployment("test-redeploy-1.war");
+        final Deployment deployment2 = createDefaultDeployment("test-redeploy-2.war");
+        final Deployment deployment3 = createDefaultDeployment("test-redeploy-3.war");
+        final Set<Deployment> allDeployments = newSet(deployment1, deployment2, deployment3);
+
+        // Redeploy should fail as the deployment should not exist
+        assertFailed(deploymentManager.redeploy(allDeployments));
+
+        // Deploy just two of the deployments, then attempt to redeploy all 3 which should fail since one of them could
+        // not be redeployed
+        final Map<Deployment, DeployResult> deployResults = deployForSuccess(newSet(deployment1, deployment2));
+        assertFailed(deploymentManager.redeploy(allDeployments));
+
+        // Deploy the third deployment content, the redeploy all for a successful redeploy
+        deployResults.put(deployment3, deployForSuccess(deployment3));
+        final Map<Deployment, DeployResult> currentDeployResults = redeployForSuccess(allDeployments);
+
+        Assert.assertEquals("Expected the same size for the original deployment results and the redeploy results",
+                deployResults.size(), currentDeployResults.size());
+        Assert.assertTrue(deployResults.keySet().containsAll(currentDeployResults.keySet()));
+
+        // Skip time checks on domain until WFCORE-1667 is fixed
+        final boolean checkTime = !ServerHelper.isDomainServer(getClient());
+
+        for (Deployment deployment : allDeployments) {
+            final DeployResult deployResult = deployResults.get(deployment);
+            final DeployResult currentDeployResult = currentDeployResults.get(deployment);
+            // Compare the original hash and the new hash, they should be equal as the content is exactly the same. However
+            // the timestamps should not be equal as the content should have been replaced and therefore undeployed, then
+            // redeployed.
+            Assert.assertArrayEquals(
+                    String.format("Expected hash to be equal: %nExpected: %s%nFound: %s%n", bytesToHexString(deployResult.hash),
+                            bytesToHexString(currentDeployResult.hash)),
+                    deployResult.hash, currentDeployResult.hash);
+            if (checkTime) {
+                Assert.assertNotEquals("Last enabled times should not match.", deployResult.enabledTime, currentDeployResult.enabledTime);
+            }
+        }
+    }
+
+    @Test
+    public void testRedeployToRuntime() throws Exception {
+        // There is a bug in WildFly, fixed in 10.1.0, using a full-replace-deployment operation when the enabled
+        // attribute is set to false. Do not test a redeploy with a disabled deployment here as it will remove all
+        // subsystems. See WFCORE-1577.
+
+        final String deploymentName = "test-runtime-redeploy.war";
+        final Deployment deployment = createDefaultDeployment(deploymentName);
+
+        final DeployResult deployResult = deployForSuccess(deployment);
+
+        // Deploy the content to the runtime, this should result in the enabled field resulting in true
+        final DeployResult currentDeployResult = createResult(deploymentManager.redeployToRuntime(deployment), deployment);
+        final DeploymentResult result = currentDeployResult.deploymentResult;
+        assertSuccess(result);
+        assertDeploymentExists(deployment, true);
+        Assert.assertArrayEquals(
+                String.format("Expected hash to be equal: %nExpected: %s%nFound: %s%n", bytesToHexString(deployResult.hash),
+                        bytesToHexString(currentDeployResult.hash)),
+                deployResult.hash, currentDeployResult.hash);
+        // Timestamps should match as a redeploy only redploy's deploys the runtime not the content
+        Assert.assertEquals("Last enabled times should not match.", deployResult.enabledTime, currentDeployResult.enabledTime);
+    }
+
+    @Test
+    public void testRedeployToRuntimeMulti() throws Exception {
+        // There is a bug in WildFly, fixed in 10.1.0, using a full-replace-deployment operation when the enabled
+        // attribute is set to false. Do not test a redeploy with a disabled deployment here as it will remove all
+        // subsystems. See WFCORE-1577.
+
+        final Deployment deployment1 = createDefaultDeployment("test-runtime-redeploy-1.war");
+        final Deployment deployment2 = createDefaultDeployment("test-runtime-redeploy-2.war");
+        final Deployment deployment3 = createDefaultDeployment("test-runtime-redeploy-3.war");
+        final Set<Deployment> allDeployments = newSet(deployment1, deployment2, deployment3);
+        final Map<Deployment, DeployResult> deployResults = deployForSuccess(allDeployments);
+
+        // Deploy the content to the runtime, this should result in the enabled field resulting in true
+        final Map<Deployment, DeployResult> currentDeployResults = createResult(
+                deploymentManager.redeployToRuntime(newSet((DeploymentDescription) deployment1, deployment2, deployment3)),
+                allDeployments);
+
+        Assert.assertEquals("Expected the same size for the original deployment results and the redeploy results",
+                deployResults.size(), currentDeployResults.size());
+        Assert.assertTrue(deployResults.keySet().containsAll(currentDeployResults.keySet()));
+
+        // Skip time checks on domain until WFCORE-1667 is fixed
+        final boolean checkTime = !ServerHelper.isDomainServer(getClient());
+
+        for (Deployment deployment : allDeployments) {
+            final DeployResult deployResult = deployResults.get(deployment);
+            final DeployResult currentDeployResult = currentDeployResults.get(deployment);
+            Assert.assertArrayEquals(
+                    String.format("Expected hash to be equal: %nExpected: %s%nFound: %s%n", bytesToHexString(deployResult.hash),
+                            bytesToHexString(currentDeployResult.hash)),
+                    deployResult.hash, currentDeployResult.hash);
+            if (checkTime) {
+                // Timestamps should match as a redeploy only redploy's deploys the runtime not the content
+                Assert.assertEquals("Last enabled times should not match.", deployResult.enabledTime, currentDeployResult.enabledTime);
+            }
+        }
+    }
+
+    @Test
+    public void testUndeploy() throws Exception {
+        final String deploymentName = "test-undeploy.war";
+        final Deployment deployment = createDefaultDeployment(deploymentName);
+
+        // First undeploy and don't fail on a missing deployment
+        undeployForSuccess(UndeployDescription.of(deployment)
+                        .setFailOnMissing(false),
+                false);
+
+        // Test an undeploy that should fail since it's missing
+        assertFailed(deploymentManager.undeploy(
+                UndeployDescription.of(deployment)
+                        .setFailOnMissing(true)
+        ));
+        assertDeploymentDoesNotExist(deployment);
+
+        // Deploy the content so it can be undeployed, but leave the content itself on the server. This should result in
+        // the enabled being false and the disabled-time being defined.
+        deployForSuccess(deployment);
+
+        undeployForSuccess(
+                UndeployDescription.of(deployment)
+                        .setRemoveContent(false)
+                , true);
+
+        // Deploy the content back to the runtime
+        assertSuccess(deploymentManager.deployToRuntime(deployment));
+
+        // Undeploy the content completely, the content should no longer be in the container
+        undeployForSuccess(
+                UndeployDescription.of(deployment)
+                        .setRemoveContent(true)
+                , false);
+
+    }
+
+    @Test
+    public void testUndeployMulti() throws Exception {
+        final Deployment deployment1 = createDefaultDeployment("test-undeploy-1.war");
+        final Deployment deployment2 = createDefaultDeployment("test-undeploy-2.war");
+        final Deployment deployment3 = createDefaultDeployment("test-undeploy-3.war");
+
+        // First undeploy and don't fail on a missing deployment
+        assertSuccess(deploymentManager.undeploy(
+                newSet(UndeployDescription.of(deployment1).setFailOnMissing(false),
+                        UndeployDescription.of(deployment2).setFailOnMissing(false))
+                )
+        );
+
+        // Test an undeploy that should fail since it's missing
+        assertFailed(deploymentManager.undeploy(
+                newSet(UndeployDescription.of(deployment1).setFailOnMissing(false),
+                        UndeployDescription.of(deployment2).setFailOnMissing(true),
+                        UndeployDescription.of(deployment3).setFailOnMissing(false))
+                )
+        );
+
+        // Deploy the content so it can be undeployed, but leave the content itself on the server. This should result in
+        // the enabled being false and the disabled-time being defined.
+        deployForSuccess(newSet(deployment1, deployment2, deployment3));
+
+        // Remove all deployments, leaving deployment1 and deployment2 content, but removing deployment3's content
+        assertSuccess(deploymentManager.undeploy(
+                newSet(UndeployDescription.of(deployment1).setRemoveContent(false),
+                        UndeployDescription.of(deployment2).setRemoveContent(false),
+                        UndeployDescription.of(deployment3).setRemoveContent(true)
+                )
+        ));
+
+        assertDeploymentExists(deployment1, false);
+        assertDeploymentExists(deployment2, false);
+        assertDeploymentDoesNotExist(deployment3);
+
+        // Deploy the content back to the runtime
+        assertSuccess(deploymentManager.deployToRuntime(newSet((DeploymentDescription) deployment1, deployment2)));
+
+        // Undeploy remaining
+        assertSuccess(deploymentManager.undeploy(
+                newSet(UndeployDescription.of(deployment1).setRemoveContent(true),
+                        UndeployDescription.of(deployment2).setRemoveContent(true)
+                )
+        ));
+        assertDeploymentDoesNotExist(deployment1);
+        assertDeploymentDoesNotExist(deployment2);
+    }
+
+    protected abstract ModelControllerClient getClient();
+
+    protected abstract ModelNode createDeploymentResourceAddress(String deploymentName) throws IOException;
+
+    void assertSuccess(final DeploymentResult result) {
+        if (!result.successful()) {
+            Assert.fail(result.getFailureMessage());
+        }
+    }
+
+    void assertFailed(final DeploymentResult result) {
+        Assert.assertFalse("Deployment was expected to fail.", result.successful());
+    }
+
+    void assertDeploymentExists(final DeploymentDescription deployment) throws IOException {
+        Assert.assertTrue(String.format("Expected deployment %s to exist in the content repository.", deployment),
+                deploymentManager.hasDeployment(deployment.getName()));
+        for (String serverGroup : deployment.getServerGroups()) {
+            Assert.assertTrue(String.format("Expected deployment %s to exist in the content repository.", deployment),
+                    deploymentManager.hasDeployment(deployment.getName(), serverGroup));
+        }
+    }
+
+    void assertDeploymentExists(final DeploymentDescription deployment, final boolean shouldBeEnabled) throws IOException {
+        Assert.assertTrue(String.format("Expected deployment %s to exist in the content repository.", deployment),
+                deploymentManager.hasDeployment(deployment.getName()));
+        final Set<String> serverGroups = deployment.getServerGroups();
+        if (serverGroups.isEmpty()) {
+            Assert.assertEquals(String.format("Expected enabled attribute to be %s for deployment %s", shouldBeEnabled, deployment),
+                    shouldBeEnabled, deploymentManager.isEnabled(deployment.getName()));
+        } else {
+            for (String serverGroup : serverGroups) {
+                Assert.assertTrue(String.format("Expected deployment %s to exist on %s.", deployment, serverGroup),
+                        deploymentManager.hasDeployment(deployment.getName(), serverGroup));
+                Assert.assertEquals(String.format("Expected enabled attribute to be %s for deployment %s on server group %s",
+                        shouldBeEnabled, deployment, serverGroup),
+                        shouldBeEnabled, deploymentManager.isEnabled(deployment.getName(), serverGroup));
+            }
+        }
+    }
+
+    void assertDeploymentDoesNotExist(final DeploymentDescription deployment) throws IOException {
+        Assert.assertFalse(String.format("Expected deployment %s to not exist.", deployment),
+                deploymentManager.hasDeployment(deployment.getName()));
+    }
+
+    void assertDeploymentEnabled(final DeploymentDescription deployment) throws IOException {
+        final Set<String> serverGroups = deployment.getServerGroups();
+        if (serverGroups.isEmpty()) {
+            Assert.assertTrue(String.format("Expected deployment %s to be enabled", deployment), deploymentManager.isEnabled(deployment.getName()));
+        } else {
+            for (String serverGroup : serverGroups) {
+                Assert.assertTrue(String.format("Expected deployment %s to be enabled on %s", deployment, serverGroup),
+                        deploymentManager.isEnabled(deployment.getName(), serverGroup));
+            }
+        }
+    }
+
+    void assertDeploymentDisabled(final DeploymentDescription deployment) throws IOException {
+        final Set<String> serverGroups = deployment.getServerGroups();
+        if (serverGroups.isEmpty()) {
+            Assert.assertFalse(String.format("Expected deployment %s to be disabled", deployment), deploymentManager.isEnabled(deployment.getName()));
+        } else {
+            for (String serverGroup : serverGroups) {
+                Assert.assertFalse(String.format("Expected deployment %s to be disabled on %s", deployment, serverGroup),
+                        deploymentManager.isEnabled(deployment.getName(), serverGroup));
+            }
+        }
+    }
+
+    DeployResult deployForSuccess(final Deployment deployment) throws IOException {
+        return deployForSuccess(deployment, false);
+    }
+
+    DeployResult deployForSuccess(final Deployment deployment, final boolean force) throws IOException {
+        final DeploymentResult result;
+        if (force) {
+            result = deploymentManager.forceDeploy(deployment);
+        } else {
+            result = deploymentManager.deploy(deployment);
+        }
+        assertSuccess(result);
+        assertDeploymentExists(deployment);
+        return createResult(result, deployment);
+    }
+
+    Map<Deployment, DeployResult> deployForSuccess(final Set<Deployment> deployments) throws IOException, InterruptedException {
+        return deployForSuccess(deployments, false);
+    }
+
+    Map<Deployment, DeployResult> deployForSuccess(final Set<Deployment> deployments, final boolean force) throws IOException, InterruptedException {
+        final DeploymentResult result;
+        if (force) {
+            result = deploymentManager.forceDeploy(deployments);
+        } else {
+            result = deploymentManager.deploy(deployments);
+        }
+        assertSuccess(result);
+        final Map<Deployment, DeployResult> results = new LinkedHashMap<>();
+        for (Deployment deployment : deployments) {
+            assertDeploymentExists(deployment);
+            results.put(deployment, createResult(result, deployment));
+        }
+        return results;
+    }
+
+    DeployResult redeployForSuccess(final Deployment deployment) throws IOException {
+        final DeploymentResult result = deploymentManager.redeploy(deployment);
+        assertSuccess(result);
+        assertDeploymentExists(deployment);
+        return createResult(result, deployment);
+    }
+
+    Map<Deployment, DeployResult> redeployForSuccess(final Set<Deployment> deployments) throws IOException {
+        final DeploymentResult result = deploymentManager.redeploy(deployments);
+        assertSuccess(result);
+        final Map<Deployment, DeployResult> results = new LinkedHashMap<>();
+        for (Deployment deployment : deployments) {
+            assertDeploymentExists(deployment);
+            results.put(deployment, createResult(result, deployment));
+        }
+        return results;
+    }
+
+    DeploymentResult undeployForSuccess(final UndeployDescription deployment, final boolean contentShouldExist) throws IOException {
+        return undeployForSuccess(deployment, deployment.getServerGroups(), contentShouldExist);
+    }
+
+    DeploymentResult undeployForSuccess(final UndeployDescription deployment, final Set<String> expectedServerGroups,
+                                        final boolean contentShouldExist) throws IOException {
+        final DeploymentResult result = deploymentManager.undeploy(deployment);
+        assertSuccess(result);
+        if (contentShouldExist) {
+            final DeploymentDescription copy = SimpleDeploymentDescription.of(deployment.getName(), expectedServerGroups);
+            assertDeploymentExists(copy, false);
+        } else {
+            // There's no need to check the server-groups, if the content is no longer in the repository it can't be on
+            // the server groups.
+            assertDeploymentDoesNotExist(deployment);
+        }
+        return result;
+    }
+
+    ModelNode executeOp(final ModelNode op) throws IOException {
+        final ModelNode result = getClient().execute(op);
+        if (Operations.isSuccessfulOutcome(result)) {
+            return Operations.readResult(result);
+        }
+        Assert.fail(String.format("Operation %s failed: %s", op, Operations.getFailureDescription(result)));
+        // Should never be reached
+        return new ModelNode();
+    }
+
+    Deployment createDefaultDeployment(final String name) {
+        return createDeployment(createDefaultArchive(name));
+    }
+
+    Deployment createDeployment(final Archive<?> archive) {
+        return Deployment.of(archive.as(ZipExporter.class).exportAsInputStream(), archive.getName());
+    }
+
+    private byte[] readDeploymentHash(final String deploymentName) throws IOException {
+        final ModelNode op = Operations.createReadAttributeOperation(DeploymentOperations.createAddress(ClientConstants.DEPLOYMENT, deploymentName), ClientConstants.CONTENT);
+        // Response should be a list, we only need the first entry
+        final ModelNode response = executeOp(op).get(0);
+        if (response.hasDefined("hash")) {
+            return response.get("hash").asBytes();
+        }
+        return new byte[0];
+    }
+
+    private long readLastEnabledTime(final ModelNode address) throws IOException {
+        final ModelNode op = Operations.createReadAttributeOperation(address, "enabled-time");
+        final ModelNode response = executeOp(op);
+        return response.isDefined() ? response.asLong() : 0L;
+    }
+
+    private DeployResult createResult(final DeploymentResult result, final Deployment deployment) throws IOException {
+        return new DeployResult(result, deployment, readDeploymentHash(deployment.getName()),
+                readLastEnabledTime(createDeploymentResourceAddress(deployment.getName())));
+    }
+
+    private Map<Deployment, DeployResult> createResult(final DeploymentResult result, final Collection<Deployment> deployments) throws IOException {
+        final Map<Deployment, DeployResult> results = new LinkedHashMap<>(deployments.size());
+        for (Deployment deployment : deployments) {
+            results.put(deployment, createResult(result, deployment));
+        }
+        return results;
+    }
+
+    static WebArchive createDefaultArchive(final String name) {
+        return ShrinkWrap.create(WebArchive.class, name)
+                .addClass(Simple.class);
+    }
+
+    static void safeClose(final Closeable closeable) {
+        if (closeable != null) try {
+            closeable.close();
+        } catch (Exception ignore) {
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    static <E> Set<E> newSet(final E... entries) {
+        final Set<E> result = new LinkedHashSet<>();
+        Collections.addAll(result, entries);
+        return result;
+    }
+
+    private static String bytesToHexString(final byte[] bytes) {
+        final StringBuilder builder = new StringBuilder(bytes.length * 2);
+        for (byte b : bytes) {
+            //noinspection MagicNumber
+            builder.append(hexChars[b >> 4 & 0x0f]).append(hexChars[b & 0x0f]);
+        }
+        return builder.toString();
+    }
+
+    @SuppressWarnings("unused")
+    static class DeployResult {
+        private final DeploymentResult deploymentResult;
+        private final Deployment deployment;
+        private final byte[] hash;
+        private final long enabledTime;
+
+        DeployResult(final DeploymentResult deploymentResult, final Deployment deployment, final byte[] hash, final long enabledTime) {
+            this.deploymentResult = deploymentResult;
+            this.deployment = deployment;
+            this.hash = hash;
+            this.enabledTime = enabledTime;
+        }
+    }
+
+}

--- a/core/src/test/java/org/wildfly/plugin/core/DeploymentResultTestCase.java
+++ b/core/src/test/java/org/wildfly/plugin/core/DeploymentResultTestCase.java
@@ -1,0 +1,109 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2016 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.plugin.core;
+
+import org.jboss.dmr.ModelNode;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class DeploymentResultTestCase {
+
+    @Test
+    public void testSuccessful() {
+        Assert.assertTrue(DeploymentResult.SUCCESSFUL.successful());
+        Assert.assertNull(DeploymentResult.SUCCESSFUL.getFailureMessage());
+        Assert.assertFalse(DeploymentResult.SUCCESSFUL.asModelNode().isDefined());
+
+        final DeploymentResult deploymentResult = new DeploymentResult(createCompositeOutcome());
+        Assert.assertTrue(deploymentResult.successful());
+        Assert.assertNull(deploymentResult.getFailureMessage());
+        Assert.assertTrue(deploymentResult.asModelNode().isDefined());
+    }
+
+    @Test
+    public void testFailed() {
+        // Create a failure description
+        final ModelNode failureModel = createCompositeOutcome("WFLYCTL0212: Duplicate resource [(\"deployment\" => \"foo.war\")]");
+
+        DeploymentResult deploymentResult = new DeploymentResult(failureModel);
+        Assert.assertFalse(deploymentResult.successful());
+        Assert.assertEquals("WFLYCTL0212: Duplicate resource [(\"deployment\" => \"foo.war\")]", deploymentResult.getFailureMessage());
+        Assert.assertTrue(deploymentResult.asModelNode().isDefined());
+
+        // Create a failure not based on model node
+        deploymentResult = new DeploymentResult("Test failed message");
+        Assert.assertFalse(deploymentResult.successful());
+        Assert.assertEquals("Test failed message", deploymentResult.getFailureMessage());
+        Assert.assertFalse(deploymentResult.asModelNode().isDefined());
+
+        // Create a failure not based on model node
+        deploymentResult = new DeploymentResult("Test failed message %d", 2);
+        Assert.assertFalse(deploymentResult.successful());
+        Assert.assertEquals("Test failed message 2", deploymentResult.getFailureMessage());
+        Assert.assertFalse(deploymentResult.asModelNode().isDefined());
+    }
+
+    @Test
+    public void testFailureAssertion() {
+        try {
+            new DeploymentResult("Test failure result").assertSuccess();
+            Assert.fail("Expected the deployment result to be a failure result");
+        } catch (DeploymentException ignore) {
+        }
+        try {
+            new DeploymentResult("Test failure result %d", 2).assertSuccess();
+            Assert.fail("Expected the deployment result to be a failure result");
+        } catch (DeploymentException ignore) {
+        }
+
+        // Create a failure description
+        try {
+            new DeploymentResult(createCompositeOutcome("WFLYCTL0212: Duplicate resource [(\"deployment\" => \"foo.war\")]")).assertSuccess();
+            Assert.fail("Expected the deployment result to be a failure result");
+        } catch (DeploymentException ignore) {
+        }
+    }
+
+    private static ModelNode createCompositeOutcome() {
+        return createCompositeOutcome(null);
+    }
+
+    private static ModelNode createCompositeOutcome(final String failureMessage) {
+        final ModelNode response = createOutcome(failureMessage);
+        final ModelNode result = response.get("result");
+        result.get("step-1").set(createOutcome(failureMessage));
+        return response;
+    }
+
+    private static ModelNode createOutcome(final String failureMessage) {
+        final ModelNode result = new ModelNode().setEmptyObject();
+        if (failureMessage == null) {
+            result.get("outcome").set("success");
+        } else {
+            result.get("outcome").set("failed");
+            result.get("failure-description").set(failureMessage);
+            result.get("rolled-back").set(true);
+        }
+        return result;
+    }
+}

--- a/core/src/test/java/org/wildfly/plugin/core/DeploymentTestCase.java
+++ b/core/src/test/java/org/wildfly/plugin/core/DeploymentTestCase.java
@@ -1,0 +1,97 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2016 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.plugin.core;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.wildfly.plugin.core.common.Simple;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class DeploymentTestCase {
+    private static final Path TEST_DEPLOYMENT_DIR = Paths.get(System.getProperty("test.deployment.dir", ".")).toAbsolutePath().normalize();
+    private static final String TEST_DEPLOYMENT_FILE_NAME = TEST_DEPLOYMENT_DIR.getFileName().toString();
+
+    @Test
+    public void testPathDeploymentName() {
+        final Deployment deployment = Deployment.of(TEST_DEPLOYMENT_DIR);
+        Assert.assertEquals(TEST_DEPLOYMENT_FILE_NAME, deployment.getName());
+
+        // Set the file name and expect the new name
+        final String name = "changed.war";
+        deployment.setName(name);
+        Assert.assertEquals(name, deployment.getName());
+
+        // Reset the name to null and expect the file name
+        deployment.setName(null);
+        Assert.assertEquals(TEST_DEPLOYMENT_FILE_NAME, deployment.getName());
+    }
+
+    @Test
+    public void testInputStreamDeploymentName() {
+        final String name = "test.war";
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, name)
+                .addClass(Simple.class);
+        final TestInputStream in = new TestInputStream(war);
+        final Deployment deployment = Deployment.of(in, name);
+        Assert.assertEquals(name, deployment.getName());
+        Assert.assertTrue("Expected to the input stream to be closed", in.closed.get());
+
+        // Set the file name and expect the new name
+        final String changedName = "changed.war";
+        deployment.setName(changedName);
+        Assert.assertEquals(changedName, deployment.getName());
+
+        // Reset the name to null and expect a failure
+        try {
+            deployment.setName(null);
+            Assert.fail("Expected setting the name to null for an input stream to fail.");
+        } catch (IllegalArgumentException ignore) {
+        }
+    }
+
+    private static class TestInputStream extends FilterInputStream {
+        private final AtomicBoolean closed = new AtomicBoolean(false);
+
+        private TestInputStream(final Archive<?> archive) {
+            super(archive.as(ZipExporter.class).exportAsInputStream());
+        }
+
+        @Override
+        public void close() throws IOException {
+            try {
+                super.close();
+            } finally {
+                closed.set(true);
+            }
+        }
+    }
+}

--- a/core/src/test/java/org/wildfly/plugin/core/DomainDeploymentManagerIT.java
+++ b/core/src/test/java/org/wildfly/plugin/core/DomainDeploymentManagerIT.java
@@ -1,0 +1,191 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2016 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.plugin.core;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.helpers.ClientConstants;
+import org.jboss.as.controller.client.helpers.domain.DomainClient;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.wildfly.core.launcher.DomainCommandBuilder;
+import org.wildfly.core.launcher.ProcessHelper;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class DomainDeploymentManagerIT extends AbstractDeploymentManagerTest {
+    private static final String DEFAULT_SERVER_GROUP = "main-server-group";
+
+    @SuppressWarnings("StaticVariableMayNotBeInitialized")
+    private static ServerProcess process;
+    @SuppressWarnings("StaticVariableMayNotBeInitialized")
+    private static DomainClient client;
+
+    @BeforeClass
+    public static void startServer() throws Exception {
+        boolean ok = false;
+        try {
+            client = DomainClient.Factory.create(Environment.createClient());
+            if (ServerHelper.isDomainRunning(client) || ServerHelper.isStandaloneRunning(client)) {
+                Assert.fail("A WildFly server is already running: " + ServerHelper.getContainerDescription(client));
+            }
+            final DomainCommandBuilder commandBuilder = DomainCommandBuilder.of(Environment.WILDFLY_HOME);
+            process = ServerProcess.start(commandBuilder, null, System.out);
+            ServerHelper.waitForDomain(client, Environment.TIMEOUT);
+            ok = true;
+        } finally {
+            if (!ok) {
+                final Process p = process;
+                final ModelControllerClient c = client;
+                process = null;
+                client = null;
+                try {
+                    ProcessHelper.destroyProcess(p);
+                } finally {
+                    safeClose(c);
+                }
+            }
+        }
+    }
+
+    @AfterClass
+    @SuppressWarnings("StaticVariableUsedBeforeInitialization")
+    public static void shutdown() throws Exception {
+        try {
+            if (client != null) {
+                ServerHelper.shutdownDomain(client);
+                safeClose(client);
+            }
+        } finally {
+            if (process != null) {
+                process.destroy();
+                process.waitFor();
+            }
+        }
+    }
+
+    @Test
+    public void testFailedDeploy() throws Exception {
+        // Expect a failure with no server groups defined
+        final Deployment failedDeployment = createDefaultDeployment("test-failed-deployment.war", false);
+        assertFailed(deploymentManager.deploy(failedDeployment));
+        assertDeploymentDoesNotExist(failedDeployment);
+    }
+
+    @Test
+    public void testFailedDeployMulti() throws Exception {
+        // Expect a failure with no server groups defined
+        final Set<Deployment> failedDeployments = new HashSet<>();
+        failedDeployments.add(createDefaultDeployment("test-failed-deployment-1.war"));
+        failedDeployments.add(createDefaultDeployment("test-failed-deployment-2.war", false));
+        assertFailed(deploymentManager.deploy(failedDeployments));
+        for (Deployment failedDeployment : failedDeployments) {
+            assertDeploymentDoesNotExist(failedDeployment);
+        }
+    }
+
+    @Test
+    public void testFailedForceDeploy() throws Exception {
+        // Expect a failure with no server groups defined
+        final Deployment failedDeployment = createDefaultDeployment("test-failed-deployment.war", false);
+        assertFailed(deploymentManager.forceDeploy(failedDeployment));
+        assertDeploymentDoesNotExist(failedDeployment);
+
+    }
+
+    @Test
+    public void testFailedRedeploy() throws Exception {
+        // Expect a failure with no server groups defined
+        assertFailed(deploymentManager.redeploy(createDefaultDeployment("test-redeploy.war", false)));
+    }
+
+    @Test
+    public void testFailedUndeploy() throws Exception {
+        // Undeploy with an additional server-group where the deployment does not exist
+        undeployForSuccess(
+                UndeployDescription.of("test-undeploy-multi-server-groups.war")
+                        .setFailOnMissing(false)
+                        .setRemoveContent(false)
+                        .addServerGroup("other-server-group")
+                , Collections.singleton(DEFAULT_SERVER_GROUP), false);
+
+        // Undeploy with an additional server-group where the deployment does not exist
+        final Deployment deployment = createDefaultDeployment("test-undeploy-multi-server-groups-failed.war");
+        deployForSuccess(deployment);
+        final DeploymentResult result = deploymentManager.undeploy(
+                UndeployDescription.of(deployment)
+                        .setFailOnMissing(true)
+                        .addServerGroup("other-server-group")
+        );
+        assertFailed(result);
+        assertDeploymentExists(deployment, true);
+    }
+
+    @Test
+    public void testDeploymentQueries() throws Exception {
+        Assert.assertTrue("No deployments should exist.", deploymentManager.getDeployments().isEmpty());
+        Assert.assertTrue("No deployments should exist.", deploymentManager.getDeploymentNames().isEmpty());
+        Assert.assertTrue(String.format("No deployments should exist on %s", DEFAULT_SERVER_GROUP),
+                deploymentManager.getDeployments(DEFAULT_SERVER_GROUP).isEmpty());
+    }
+
+    @Override
+    protected ModelControllerClient getClient() {
+        return client;
+    }
+
+    @Override
+    protected ModelNode createDeploymentResourceAddress(final String deploymentName) throws IOException {
+        return ServerHelper.determineHostAddress(getClient())
+                .add(ClientConstants.SERVER, "server-one")
+                .add(ClientConstants.DEPLOYMENT, deploymentName);
+    }
+
+    @Override
+    Deployment createDefaultDeployment(final String name) {
+        return createDefaultDeployment(name, true);
+    }
+
+    @Override
+    Deployment createDeployment(final Archive<?> archive) {
+        return createDeployment(archive, true);
+    }
+
+    private Deployment createDefaultDeployment(final String name, final boolean addServerGroup) {
+        return createDeployment(createDefaultArchive(name), addServerGroup);
+    }
+
+    private Deployment createDeployment(final Archive<?> archive, final boolean addServerGroup) {
+        final Deployment result = super.createDeployment(archive);
+        if (addServerGroup) {
+            result.addServerGroups(DEFAULT_SERVER_GROUP);
+        }
+        return result;
+    }
+}

--- a/core/src/test/java/org/wildfly/plugin/core/Environment.java
+++ b/core/src/test/java/org/wildfly/plugin/core/Environment.java
@@ -1,0 +1,95 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2016 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.plugin.core;
+
+import java.net.UnknownHostException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.logging.Logger;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@SuppressWarnings({"WeakerAccess", "Duplicates"})
+class Environment {
+
+    /**
+     * The default WildFly home directory specified by the {@code jboss.home} system property.
+     */
+    public static final Path WILDFLY_HOME;
+    /**
+     * The host name specified by the {@code wildfly.management.hostname} system property or {@code localhost} by
+     * default.
+     */
+    public static final String HOSTNAME = System.getProperty("wildfly.management.hostname", "localhost");
+    /**
+     * The port specified by the {@code wildfly.management.port} system property or {@code 9990} by default.
+     */
+    public static final int PORT;
+
+    /**
+     * The default server startup timeout specified by {@code wildfly.timeout}, default is 60 seconds.
+     */
+    public static final long TIMEOUT;
+
+    static {
+        final Logger logger = Logger.getLogger(Environment.class);
+
+        // Get the WildFly home directory and copy to the temp directory
+        final String wildflyDist = System.getProperty("jboss.home");
+        assert wildflyDist != null : "WildFly home property, jboss.home, was not set";
+        Path wildflyHome = Paths.get(wildflyDist);
+        validateWildFlyHome(wildflyHome);
+        WILDFLY_HOME = wildflyHome;
+
+        final String port = System.getProperty("wildfly.management.port", "9990");
+        try {
+            PORT = Integer.parseInt(port);
+        } catch (NumberFormatException e) {
+            logger.debugf(e, "Invalid port: %s", port);
+            throw new RuntimeException("Invalid port: " + port, e);
+        }
+
+        final String timeout = System.getProperty("wildfly.timeout", "60");
+        try {
+            TIMEOUT = Long.parseLong(timeout);
+        } catch (NumberFormatException e) {
+            logger.debugf(e, "Invalid timeout: %s", timeout);
+            throw new RuntimeException("Invalid timeout: " + timeout, e);
+        }
+    }
+
+    public static ModelControllerClient createClient() throws UnknownHostException {
+        return ModelControllerClient.Factory.create(HOSTNAME, PORT);
+    }
+
+    private static boolean isValidWildFlyHome(final Path wildflyHome) {
+        return Files.exists(wildflyHome) && Files.isDirectory(wildflyHome) && Files.exists(wildflyHome.resolve("jboss-modules.jar"));
+    }
+
+    private static void validateWildFlyHome(final Path wildflyHome) {
+        if (!isValidWildFlyHome(wildflyHome)) {
+            throw new RuntimeException("Invalid WildFly home directory: " + wildflyHome);
+        }
+    }
+}

--- a/core/src/test/java/org/wildfly/plugin/core/StandaloneDeploymentManagerIT.java
+++ b/core/src/test/java/org/wildfly/plugin/core/StandaloneDeploymentManagerIT.java
@@ -1,0 +1,107 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2016 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.plugin.core;
+
+import java.io.IOException;
+
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.helpers.ClientConstants;
+import org.jboss.dmr.ModelNode;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.wildfly.core.launcher.ProcessHelper;
+import org.wildfly.core.launcher.StandaloneCommandBuilder;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class StandaloneDeploymentManagerIT extends AbstractDeploymentManagerTest {
+
+    @SuppressWarnings("StaticVariableMayNotBeInitialized")
+    private static ServerProcess process;
+    @SuppressWarnings("StaticVariableMayNotBeInitialized")
+    private static ModelControllerClient client;
+
+    @BeforeClass
+    public static void startServer() throws Exception {
+        boolean ok = false;
+        try {
+            client = Environment.createClient();
+            if (ServerHelper.isDomainRunning(client) || ServerHelper.isStandaloneRunning(client)) {
+                Assert.fail("A WildFly server is already running: " + ServerHelper.getContainerDescription(client));
+            }
+            final StandaloneCommandBuilder commandBuilder = StandaloneCommandBuilder.of(Environment.WILDFLY_HOME);
+            process = ServerProcess.start(commandBuilder, null, System.out);
+            ServerHelper.waitForStandalone(client, Environment.TIMEOUT);
+            ok = true;
+        } finally {
+            if (!ok) {
+                final Process p = process;
+                final ModelControllerClient c = client;
+                process = null;
+                client = null;
+                try {
+                    ProcessHelper.destroyProcess(p);
+                } finally {
+                    safeClose(c);
+                }
+            }
+        }
+    }
+
+    @AfterClass
+    @SuppressWarnings("StaticVariableUsedBeforeInitialization")
+    public static void shutdown() throws Exception {
+        try {
+            if (client != null) {
+                ServerHelper.shutdownStandalone(client);
+                safeClose(client);
+            }
+        } finally {
+            if (process != null) {
+                process.destroy();
+                process.waitFor();
+            }
+        }
+    }
+
+    @Test
+    public void testDeploymentQueries() throws Exception {
+        Assert.assertTrue("No deployments should exist.", deploymentManager.getDeployments().isEmpty());
+        Assert.assertTrue("No deployments should exist.", deploymentManager.getDeploymentNames().isEmpty());
+        try {
+            deploymentManager.getDeployments("main-server-group");
+            Assert.fail("This is not a domain server and DeploymentManager.getDeployments(serverGroup) should have failed.");
+        } catch (IllegalStateException ignore) {
+        }
+    }
+
+    @Override
+    protected ModelControllerClient getClient() {
+        return client;
+    }
+
+    @Override
+    protected ModelNode createDeploymentResourceAddress(final String deploymentName) throws IOException {
+        return DeploymentOperations.createAddress(ClientConstants.DEPLOYMENT, deploymentName);
+    }
+}

--- a/core/src/test/java/org/wildfly/plugin/core/common/Simple.java
+++ b/core/src/test/java/org/wildfly/plugin/core/common/Simple.java
@@ -1,0 +1,26 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2016 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.plugin.core.common;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class Simple {
+}

--- a/plugin/src/main/java/org/wildfly/plugin/deployment/MavenDeployment.java
+++ b/plugin/src/main/java/org/wildfly/plugin/deployment/MavenDeployment.java
@@ -120,6 +120,9 @@ public class MavenDeployment {
                         result = deploymentManager.undeploy(UndeployDescription.of(name).addServerGroups(serverGroups).setFailOnMissing(true));
                     } else {
                         final Set<UndeployDescription> matchedDeployments = findDeployments(true);
+                        if (matchedDeployments.isEmpty()) {
+                            throw new MojoDeploymentException("No deployments matched the match-pattern %s.", matchPattern);
+                        }
                         result = deploymentManager.undeploy(matchedDeployments);
                     }
                     break;
@@ -129,6 +132,9 @@ public class MavenDeployment {
                         result = deploymentManager.undeploy(UndeployDescription.of(name).addServerGroups(serverGroups).setFailOnMissing(false));
                     } else {
                         final Set<UndeployDescription> matchedDeployments = findDeployments(false);
+                        if (matchedDeployments.isEmpty()) {
+                            return;
+                        }
                         result = deploymentManager.undeploy(matchedDeployments);
                     }
                     break;

--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,9 @@
         <wildfly.scm.connection>scm:git://github.com/wildfly/wildfly-maven-plugin.git</wildfly.scm.connection>
         <wildfly.scm.developer.connection>scm:git:git@github.com:wildfly/wildfly-maven-plugin.git</wildfly.scm.developer.connection>
         <wildfly.scm.url>http://github.com/wildfly/wildfly-maven-plugin</wildfly.scm.url>
+
+        <!-- Other properties -->
+        <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
     </properties>
 
     <modules>
@@ -128,6 +131,13 @@
                     <groupId>org.eclipse.sisu</groupId>
                     <artifactId>sisu-maven-plugin</artifactId>
                     <version>${version.org.eclipse.sisu}</version>
+                </plugin>
+
+                <plugin>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <configuration>
+                        <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/tests/domain-tests/src/test/java/org/wildfly/plugin/deployment/UndeploymentMatchTest.java
+++ b/tests/domain-tests/src/test/java/org/wildfly/plugin/deployment/UndeploymentMatchTest.java
@@ -25,7 +25,6 @@ package org.wildfly.plugin.deployment;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -66,12 +65,13 @@ public class UndeploymentMatchTest extends AbstractWildFlyServerMojoTest {
 
     @After
     public void cleanup() throws Exception {
-        final Collection<DeploymentDescription> deployments = deploymentManager.getDeployments();
-        final Set<UndeployDescription> toRemove = new HashSet<>();
-        for (DeploymentDescription deployment : deployments) {
-            toRemove.add(UndeployDescription.of(deployment).setFailOnMissing(false));
+        final Set<UndeployDescription> deployments = new HashSet<>();
+        for (DeploymentDescription deployment : deploymentManager.getDeployments()) {
+            deployments.add(UndeployDescription.of(deployment));
         }
-        deploymentManager.undeploy(toRemove);
+        if (!deployments.isEmpty()) {
+            deploymentManager.undeploy(deployments).assertSuccess();
+        }
     }
 
     @Test

--- a/tests/domain-tests/src/test/java/org/wildfly/plugin/server/DomainTestServer.java
+++ b/tests/domain-tests/src/test/java/org/wildfly/plugin/server/DomainTestServer.java
@@ -28,10 +28,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.client.helpers.domain.DomainClient;
 import org.wildfly.core.launcher.DomainCommandBuilder;
-import org.wildfly.core.launcher.Launcher;
 import org.wildfly.core.launcher.ProcessHelper;
 import org.wildfly.plugin.core.DeploymentManager;
 import org.wildfly.plugin.core.ServerHelper;
+import org.wildfly.plugin.core.ServerProcess;
 import org.wildfly.plugin.tests.Environment;
 
 /**
@@ -53,10 +53,7 @@ public class DomainTestServer implements TestServer {
                 final DomainCommandBuilder commandBuilder = DomainCommandBuilder.of(Environment.WILDFLY_HOME)
                         .setBindAddressHint("management", Environment.HOSTNAME)
                         .addHostControllerJavaOption("-Djboss.management.http.port=" + Environment.PORT);
-                final Process process = Launcher.of(commandBuilder)
-                        .setRedirectErrorStream(true)
-                        .launch();
-                startConsoleConsumer(process);
+                final Process process = ServerProcess.start(commandBuilder, null, System.out);
                 shutdownThread = ProcessHelper.addShutdownHook(process);
                 client = DomainClient.Factory.create(ModelControllerClient.Factory.create(Environment.HOSTNAME, Environment.PORT));
                 currentProcess = process;
@@ -119,14 +116,5 @@ public class DomainTestServer implements TestServer {
         } finally {
             currentProcess = null;
         }
-    }
-
-    private static Thread startConsoleConsumer(final Process process) {
-        @SuppressWarnings("UseOfSystemOutOrSystemErr")
-        final Thread result = new Thread(new ConsoleConsumer(process.getInputStream(), System.out));
-        result.setDaemon(true);
-        result.setName("Process-Console-Consumer");
-        result.start();
-        return result;
     }
 }

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -85,7 +85,6 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <systemPropertyVariables>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                         <jboss.home>${jboss.home}</jboss.home>

--- a/tests/shared/src/main/java/org/wildfly/plugin/server/TestServer.java
+++ b/tests/shared/src/main/java/org/wildfly/plugin/server/TestServer.java
@@ -22,10 +22,6 @@
 
 package org.wildfly.plugin.server;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.PrintStream;
-
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.wildfly.plugin.core.DeploymentManager;
 
@@ -41,27 +37,4 @@ public interface TestServer {
     ModelControllerClient getClient();
 
     DeploymentManager getDeploymentManager();
-
-    class ConsoleConsumer implements Runnable {
-        private final InputStream in;
-        private final PrintStream out;
-
-        ConsoleConsumer(final InputStream in, final PrintStream out) {
-            this.in = in;
-            this.out = out;
-        }
-
-
-        @Override
-        public void run() {
-            byte[] buffer = new byte[64];
-            try {
-                int len;
-                while ((len = in.read(buffer)) != -1) {
-                    out.write(buffer, 0, len);
-                }
-            } catch (IOException ignore) {
-            }
-        }
-    }
 }

--- a/tests/standalone-tests/src/test/java/org/wildfly/plugin/server/StandaloneTestServer.java
+++ b/tests/standalone-tests/src/test/java/org/wildfly/plugin/server/StandaloneTestServer.java
@@ -26,11 +26,11 @@ import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.jboss.as.controller.client.ModelControllerClient;
-import org.wildfly.core.launcher.Launcher;
 import org.wildfly.core.launcher.ProcessHelper;
 import org.wildfly.core.launcher.StandaloneCommandBuilder;
 import org.wildfly.plugin.core.DeploymentManager;
 import org.wildfly.plugin.core.ServerHelper;
+import org.wildfly.plugin.core.ServerProcess;
 import org.wildfly.plugin.tests.Environment;
 
 /**
@@ -50,10 +50,7 @@ public class StandaloneTestServer implements TestServer {
                 final StandaloneCommandBuilder commandBuilder = StandaloneCommandBuilder.of(Environment.WILDFLY_HOME)
                         .setBindAddressHint("management", Environment.HOSTNAME)
                         .addJavaOption("-Djboss.management.http.port=" + Environment.PORT);
-                final Process process = Launcher.of(commandBuilder)
-                        .setRedirectErrorStream(true)
-                        .launch();
-                startConsoleConsumer(process);
+                final Process process = ServerProcess.start(commandBuilder, null, System.out);
                 shutdownThread = ProcessHelper.addShutdownHook(process);
                 client = ModelControllerClient.Factory.create(Environment.HOSTNAME, Environment.PORT);
                 currentProcess = process;
@@ -116,11 +113,5 @@ public class StandaloneTestServer implements TestServer {
         } finally {
             currentProcess = null;
         }
-    }
-
-    private static Thread startConsoleConsumer(final Process process) {
-        final Thread result = new Thread(new ConsoleConsumer(process.getInputStream(), System.out));
-        result.start();
-        return result;
     }
 }


### PR DESCRIPTION
@jmazzitelli Just an FYI I've changed the result of the `DeploymentResult.asModelNode()` if you're using it at all. Before it returned just the result portion of the response, `Operations.readResult(result)`. Now it returns the original response so if you're using that method you might need to make some changes.

Basically before you would have gotten
```
{
    "step-1" => {"outcome" => "success"},
    "step-2" => {"outcome" => "success"}
}
```

Now you'll get the full response
```
{
    "outcome" => "success",
    "result" => {
        "step-1" => {"outcome" => "success"},
        "step-2" => {"outcome" => "success"}
    }
}
```