### PR TITLE
[WFMP-9] Add a URL parameter to the deploy-only and redploy-only goals. 

### DIFF
--- a/plugin/src/main/java/org/wildfly/plugin/common/PropertyNames.java
+++ b/plugin/src/main/java/org/wildfly/plugin/common/PropertyNames.java
@@ -37,6 +37,8 @@ public interface PropertyNames {
 
     String DEPLOY_FORCE = "deploy.force";
 
+    String DEPLOYMENT_CONTENT_URL = "wildfly.deployment.contentUrl";
+
     String DEPLOYMENT_FILENAME = "wildfly.deployment.filename";
 
     String DEPLOYMENT_NAME = "wildfly.deployment.name";

--- a/plugin/src/main/java/org/wildfly/plugin/deployment/AbstractDeployment.java
+++ b/plugin/src/main/java/org/wildfly/plugin/deployment/AbstractDeployment.java
@@ -163,7 +163,7 @@ abstract class AbstractDeployment extends AbstractServerConnection {
             commandExecutor.execute(client, beforeDeployment);
     }
 
-    protected abstract DeploymentResult executeDeployment(DeploymentManager deploymentManager, Deployment deployment) throws IOException;
+    protected abstract DeploymentResult executeDeployment(DeploymentManager deploymentManager, Deployment deployment) throws IOException, MojoDeploymentException;
 
     protected void afterDeployment(final ModelControllerClient client) throws MojoExecutionException, MojoFailureException, IOException {
 

--- a/plugin/src/main/java/org/wildfly/plugin/deployment/AbstractDeployment.java
+++ b/plugin/src/main/java/org/wildfly/plugin/deployment/AbstractDeployment.java
@@ -141,7 +141,7 @@ abstract class AbstractDeployment extends AbstractServerConnection {
             // Deploy the deployment
             getLog().debug("Executing deployment");
 
-            final Deployment deployment = createDeployment();
+            final Deployment deployment = configureDeployment(createDeployment());
 
             final DeploymentResult result = executeDeployment(DeploymentManager.Factory.create(client), deployment);
             if (!result.successful()) {
@@ -173,10 +173,7 @@ abstract class AbstractDeployment extends AbstractServerConnection {
     }
 
     protected Deployment createDeployment() {
-        return Deployment.of(file())
-                .setName(name)
-                .setRuntimeName(runtimeName)
-                .addServerGroups(getServerGroups());
+        return Deployment.of(file());
     }
 
     /**
@@ -196,6 +193,12 @@ abstract class AbstractDeployment extends AbstractServerConnection {
         } else if (hasServerGroups) {
             throw new MojoDeploymentException("Server is running in standalone mode, but server groups have been defined.");
         }
+    }
+
+    private Deployment configureDeployment(final Deployment deployment) {
+        return deployment.setName(name)
+                .setRuntimeName(runtimeName)
+                .addServerGroups(getServerGroups());
     }
 
     private Collection<String> getServerGroups() {

--- a/plugin/src/main/java/org/wildfly/plugin/deployment/DeployOnlyMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/deployment/DeployOnlyMojo.java
@@ -23,9 +23,14 @@
 package org.wildfly.plugin.deployment;
 
 
+import java.net.URL;
+
 import org.apache.maven.plugins.annotations.Execute;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.wildfly.plugin.common.PropertyNames;
+import org.wildfly.plugin.core.Deployment;
 
 /**
  * Deploys only the application to the WildFly Application Server without first invoking the
@@ -42,9 +47,26 @@ import org.apache.maven.plugins.annotations.Mojo;
 @Execute(phase = LifecyclePhase.NONE)
 public class DeployOnlyMojo extends DeployMojo {
 
+    /**
+     * A URL representing the a path to the content to be deployed. The server the content is being deployed to will
+     * require access to the URL.
+     * <p>
+     * If defined this overrides the {@code filename} and {@code targetDir} configuration parameters.
+     * </p>
+     */
+    @Parameter(alias = "content-url", property = PropertyNames.DEPLOYMENT_CONTENT_URL)
+    private URL contentUrl;
+
     @Override
     public String goal() {
         return "deploy-only";
     }
 
+    @Override
+    protected Deployment createDeployment() {
+        if (contentUrl == null) {
+            return super.createDeployment();
+        }
+        return Deployment.of(contentUrl);
+    }
 }

--- a/plugin/src/main/java/org/wildfly/plugin/deployment/RedeployMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/deployment/RedeployMojo.java
@@ -47,7 +47,11 @@ public class RedeployMojo extends AbstractAppDeployment {
     }
 
     @Override
-    protected DeploymentResult executeDeployment(final DeploymentManager deploymentManager, final Deployment deployment) throws IOException {
+    protected DeploymentResult executeDeployment(final DeploymentManager deploymentManager, final Deployment deployment) throws IOException, MojoDeploymentException {
+        // Ensure the deployment exists before attempting to redeploy it
+        if (!deploymentManager.hasDeployment(deployment.getName())) {
+            throw new MojoDeploymentException("The deployment %s does not exist in the content repository and cannot be redeployed.", deployment.getName());
+        }
         return deploymentManager.redeploy(deployment);
     }
 

--- a/plugin/src/main/java/org/wildfly/plugin/deployment/RedeployOnlyMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/deployment/RedeployOnlyMojo.java
@@ -22,9 +22,14 @@
 
 package org.wildfly.plugin.deployment;
 
+import java.net.URL;
+
 import org.apache.maven.plugins.annotations.Execute;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.wildfly.plugin.common.PropertyNames;
+import org.wildfly.plugin.core.Deployment;
 
 /**
  * Redeploys only the application to the WildFly Application Server without first invoking the
@@ -34,9 +39,27 @@ import org.apache.maven.plugins.annotations.Mojo;
 @Execute(phase = LifecyclePhase.NONE)
 public class RedeployOnlyMojo extends RedeployMojo {
 
+    /**
+     * A URL representing the a path to the content to be redeployed. The server the content is being redeployed to will
+     * require access to the URL.
+     * <p>
+     * If defined this overrides the {@code filename} and {@code targetDir} configuration parameters.
+     * </p>
+     */
+    @Parameter(alias = "content-url", property = PropertyNames.DEPLOYMENT_CONTENT_URL)
+    private URL contentUrl;
+
     @Override
     public String goal() {
         return "redeploy";
+    }
+
+    @Override
+    protected Deployment createDeployment() {
+        if (contentUrl == null) {
+            return super.createDeployment();
+        }
+        return Deployment.of(contentUrl);
     }
 
 }


### PR DESCRIPTION
This allows content in a remote repository to be deployed.

Also a commit to validate that a deployment exists before an attempt is made to redploy it.