### PR TITLE
[WFMP-69] The reload command requires a CLI specific AwaiterModelCont…

### DIFF
--- a/plugin/src/main/java/org/wildfly/plugin/cli/Commands.java
+++ b/plugin/src/main/java/org/wildfly/plugin/cli/Commands.java
@@ -62,9 +62,6 @@ public class Commands {
     @Parameter
     private List<File> scripts = new ArrayList<>();
 
-    @Parameter
-    private boolean offline = false;
-
     private final boolean failOnError;
 
     /**
@@ -81,14 +78,12 @@ public class Commands {
      * @param scripts     the scripts to execute
      * @param failOnError {@code false} if commands should continue to be executed even if the command fails,
      *                    {@code true} if to fail if a command fails after execution
-     * @param offline {@code true} if CLI should be running offline
      */
-    Commands(final boolean batch, final List<String> commands, final List<File> scripts, final boolean failOnError, final boolean offline) {
+    Commands(final boolean batch, final List<String> commands, final List<File> scripts, final boolean failOnError) {
         this.batch = batch;
         this.commands = commands;
         this.scripts = scripts;
         this.failOnError = failOnError;
-        this.offline = offline;
     }
 
     /**
@@ -145,14 +140,5 @@ public class Commands {
      */
     public boolean hasScripts() {
         return scripts != null && !scripts.isEmpty();
-    }
-
-    /**
-     * Checks if commands should be executed in offline CLI
-     * useful for embedded server
-     * @return true if offline cli should be used
-     */
-    public boolean isOffline() {
-        return offline;
     }
 }

--- a/plugin/src/main/java/org/wildfly/plugin/cli/ExecuteCommandsMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/cli/ExecuteCommandsMojo.java
@@ -38,8 +38,8 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
-import org.jboss.as.controller.client.ModelControllerClient;
 import org.wildfly.plugin.common.AbstractServerConnection;
+import org.wildfly.plugin.common.MavenModelControllerClientConfiguration;
 import org.wildfly.plugin.common.PropertyNames;
 import org.wildfly.plugin.common.StandardOutput;
 
@@ -237,8 +237,8 @@ public class ExecuteCommandsMojo extends AbstractServerConnection {
 
                 // Set the system properties for executing commands
                 System.setProperties(newSystemProperties);
-                try (ModelControllerClient client = createClient()) {
-                    commandExecutor.execute(client, jbossHome, getCommands());
+                try (MavenModelControllerClientConfiguration configuration = getClientConfiguration()) {
+                    commandExecutor.execute(configuration, jbossHome, getCommands());
                 } catch (IOException e) {
                     throw new MojoExecutionException("Could not execute commands.", e);
                 }
@@ -254,7 +254,7 @@ public class ExecuteCommandsMojo extends AbstractServerConnection {
         if (executeCommands != null) {
             return executeCommands;
         }
-        return new Commands(batch, commands, scripts, failOnError, offline);
+        return new Commands(batch, commands, scripts, failOnError);
     }
 
     private static void parseProperties(final File file, final Properties properties) throws IOException {

--- a/plugin/src/main/java/org/wildfly/plugin/common/AbstractServerConnection.java
+++ b/plugin/src/main/java/org/wildfly/plugin/common/AbstractServerConnection.java
@@ -139,7 +139,7 @@ public abstract class AbstractServerConnection extends AbstractMojo {
      *
      * @return the configuration to use
      */
-    protected synchronized ModelControllerClientConfiguration getClientConfiguration() {
+    protected synchronized MavenModelControllerClientConfiguration getClientConfiguration() {
         final Log log = getLog();
         String username = this.username;
         String password = this.password;
@@ -173,16 +173,14 @@ public abstract class AbstractServerConnection extends AbstractMojo {
                 .setHostName(hostname)
                 .setPort(port)
                 .setConnectionTimeout(timeout * 1000);
-        if (authenticationConfig == null) {
-            builder.setHandler(new ClientCallbackHandler(username, password, log));
-        } else {
+        if (authenticationConfig != null) {
             try {
                 builder.setAuthenticationConfigUri(authenticationConfig.toURI());
             } catch (URISyntaxException e) {
                 throw new RuntimeException("Failed to create URI from " + authenticationConfig, e);
             }
         }
-        return builder.build();
+        return new MavenModelControllerClientConfiguration(builder.build(), username, password);
     }
 
     private String decrypt(final Server server) {

--- a/plugin/src/main/java/org/wildfly/plugin/common/ClientCallbackHandler.java
+++ b/plugin/src/main/java/org/wildfly/plugin/common/ClientCallbackHandler.java
@@ -31,8 +31,6 @@ import javax.security.auth.callback.UnsupportedCallbackException;
 import javax.security.sasl.RealmCallback;
 import javax.security.sasl.RealmChoiceCallback;
 
-import org.apache.maven.plugin.logging.Log;
-
 /**
  * A CallbackHandler implementation to supply the username and password if required when
  * connecting to the server - if these are not available the user will be prompted to
@@ -43,13 +41,11 @@ import org.apache.maven.plugin.logging.Log;
 class ClientCallbackHandler implements CallbackHandler {
 
     private final Console console;
-    private final Log log;
     private boolean promptShown = false;
     private String username;
     private char[] password;
 
-    ClientCallbackHandler(final String username, final String password, final Log log) {
-        this.log = log;
+    ClientCallbackHandler(final String username, final String password) {
         console = System.console();
         this.username = username;
         if (password != null) {
@@ -93,7 +89,6 @@ class ClientCallbackHandler implements CallbackHandler {
     private void prompt(final String realm) {
         if (!promptShown) {
             promptShown = true;
-            log.info("Authenticating against security realm: " + realm);
         }
     }
 

--- a/plugin/src/main/java/org/wildfly/plugin/common/MavenModelControllerClientConfiguration.java
+++ b/plugin/src/main/java/org/wildfly/plugin/common/MavenModelControllerClientConfiguration.java
@@ -1,0 +1,151 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.plugin.common;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import javax.net.ssl.SSLContext;
+import javax.security.auth.callback.CallbackHandler;
+
+import org.jboss.as.controller.client.ModelControllerClientConfiguration;
+
+/**
+ * A configuration used to connect a {@link org.jboss.as.controller.client.ModelControllerClient} or used to connect a
+ * CLI {@link org.jboss.as.cli.CommandContext}.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class MavenModelControllerClientConfiguration implements ModelControllerClientConfiguration {
+
+    private final ModelControllerClientConfiguration delegate;
+    private final String username;
+    private final String password;
+    private final CallbackHandler callbackHandler;
+
+    MavenModelControllerClientConfiguration(final ModelControllerClientConfiguration delegate, final String username, final String password) {
+        this.delegate = delegate;
+        this.username = username;
+        this.password = password;
+        if (delegate.getAuthenticationConfigUri() == null) {
+            callbackHandler = new ClientCallbackHandler(username, password);
+        } else {
+            callbackHandler = delegate.getCallbackHandler();
+        }
+    }
+
+    @Override
+    public String getHost() {
+        return delegate.getHost();
+    }
+
+    @Override
+    public int getPort() {
+        return delegate.getPort();
+    }
+
+    @Override
+    public String getProtocol() {
+        return delegate.getProtocol();
+    }
+
+    @Override
+    public int getConnectionTimeout() {
+        return delegate.getConnectionTimeout();
+    }
+
+    @Override
+    public CallbackHandler getCallbackHandler() {
+        return callbackHandler;
+    }
+
+    @Override
+    public Map<String, String> getSaslOptions() {
+        return delegate.getSaslOptions();
+    }
+
+    @Override
+    public SSLContext getSSLContext() {
+        return delegate.getSSLContext();
+    }
+
+    @Override
+    public ExecutorService getExecutor() {
+        return delegate.getExecutor();
+    }
+
+    @Override
+    public String getClientBindAddress() {
+        return delegate.getClientBindAddress();
+    }
+
+    @Override
+    public URI getAuthenticationConfigUri() {
+        return delegate.getAuthenticationConfigUri();
+    }
+
+    @Override
+    public void close() throws IOException {
+        delegate.close();
+    }
+
+    /**
+     * The username provided or {@code null} if one was not provided.
+     *
+     * @return the username or {@code null}
+     */
+    public String getUsername() {
+        return username;
+    }
+
+    /**
+     * The password providedor {@code null} if one was not provided.
+     *
+     * @return the password or {@code null}
+     */
+    public char[] getPassword() {
+        if (password == null) {
+            return null;
+        }
+        return password.toCharArray();
+    }
+
+    /**
+     * Formats a connection string for CLI to use as it's controller connection.
+     *
+     * @return the controller string to connect CLI
+     */
+    public String getController() {
+        final StringBuilder controller = new StringBuilder();
+        if (getProtocol() != null) {
+            controller.append(getProtocol()).append("://");
+        }
+        if (getHost() != null) {
+            controller.append(getHost());
+        } else {
+            controller.append("localhost");
+        }
+        if (getPort() > 0) {
+            controller.append(':').append(getPort());
+        }
+        return controller.toString();
+    }
+}

--- a/plugin/src/main/java/org/wildfly/plugin/deployment/UndeployArtifactMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/deployment/UndeployArtifactMojo.java
@@ -41,6 +41,7 @@ import org.jboss.as.controller.client.ModelControllerClient;
 import org.wildfly.plugin.cli.CommandExecutor;
 import org.wildfly.plugin.cli.Commands;
 import org.wildfly.plugin.common.AbstractServerConnection;
+import org.wildfly.plugin.common.MavenModelControllerClientConfiguration;
 import org.wildfly.plugin.common.PropertyNames;
 import org.wildfly.plugin.core.DeploymentManager;
 import org.wildfly.plugin.core.DeploymentResult;
@@ -166,15 +167,18 @@ public class UndeployArtifactMojo extends AbstractServerConnection {
             deploymentName = name;
         }
         final DeploymentResult result;
-        try (ModelControllerClient client = createClient()) {
+        try (
+                ModelControllerClient client = createClient();
+                MavenModelControllerClientConfiguration configuration = getClientConfiguration();
+        ) {
             if (beforeDeployment != null) {
-                commandExecutor.execute(client, beforeDeployment);
+                commandExecutor.execute(configuration, beforeDeployment);
             }
             final boolean failOnMissing = !ignoreMissingDeployment;
             final DeploymentManager deploymentManager = DeploymentManager.Factory.create(client);
             result = deploymentManager.undeploy(UndeployDescription.of(deploymentName).addServerGroups(getServerGroups()).setFailOnMissing(failOnMissing));
             if (afterDeployment != null) {
-                commandExecutor.execute(client, afterDeployment);
+                commandExecutor.execute(configuration, afterDeployment);
             }
         } catch (IOException e) {
             throw new MojoFailureException(String.format("Failed to execute %s goal.", goal()), e);

--- a/plugin/src/main/java/org/wildfly/plugin/deployment/UndeployMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/deployment/UndeployMojo.java
@@ -40,6 +40,7 @@ import org.jboss.as.controller.client.ModelControllerClient;
 import org.wildfly.plugin.cli.CommandExecutor;
 import org.wildfly.plugin.cli.Commands;
 import org.wildfly.plugin.common.AbstractServerConnection;
+import org.wildfly.plugin.common.MavenModelControllerClientConfiguration;
 import org.wildfly.plugin.common.PropertyNames;
 import org.wildfly.plugin.core.DeploymentDescription;
 import org.wildfly.plugin.core.DeploymentManager;
@@ -155,9 +156,12 @@ public class UndeployMojo extends AbstractServerConnection {
             getLog().debug(String.format("Ignoring packaging type %s.", packageType.getPackaging()));
         } else {
             final DeploymentResult result;
-            try (ModelControllerClient client = createClient()) {
+            try (
+                    ModelControllerClient client = createClient();
+                    MavenModelControllerClientConfiguration configuration = getClientConfiguration()
+            ) {
                 if (beforeDeployment != null) {
-                    commandExecutor.execute(client, beforeDeployment);
+                    commandExecutor.execute(configuration, beforeDeployment);
                 }
                 final boolean failOnMissing = !ignoreMissingDeployment;
                 final DeploymentManager deploymentManager = DeploymentManager.Factory.create(client);
@@ -175,7 +179,7 @@ public class UndeployMojo extends AbstractServerConnection {
                     result = deploymentManager.undeploy(matchedDeployments);
                 }
                 if (afterDeployment != null) {
-                    commandExecutor.execute(client, afterDeployment);
+                    commandExecutor.execute(configuration, afterDeployment);
                 }
             } catch (IOException e) {
                 throw new MojoFailureException("Failed to execute undeploy goal.", e);

--- a/plugin/src/main/java/org/wildfly/plugin/server/RunMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/server/RunMojo.java
@@ -48,6 +48,7 @@ import org.wildfly.core.launcher.StandaloneCommandBuilder;
 import org.wildfly.plugin.cli.CommandExecutor;
 import org.wildfly.plugin.cli.Commands;
 import org.wildfly.plugin.common.AbstractServerConnection;
+import org.wildfly.plugin.common.MavenModelControllerClientConfiguration;
 import org.wildfly.plugin.common.PropertyNames;
 import org.wildfly.plugin.core.Deployment;
 import org.wildfly.plugin.core.DeploymentManager;
@@ -290,9 +291,12 @@ public class RunMojo extends AbstractServerConnection {
             // Start the server
             log.info("Server is starting up. Press CTRL + C to stop the server.");
             Process process = startContainer(commandBuilder);
-            try (ModelControllerClient client = createClient()) {
+            try (
+                    ModelControllerClient client = createClient();
+                    MavenModelControllerClientConfiguration configuration = getClientConfiguration();
+            ) {
                 if (beforeDeployment != null) {
-                    commandExecutor.execute(client, wildflyPath, beforeDeployment);
+                    commandExecutor.execute(configuration, wildflyPath, beforeDeployment);
                 }
                 final Deployment deployment = Deployment.of(deploymentContent)
                         .setName(name)
@@ -300,7 +304,7 @@ public class RunMojo extends AbstractServerConnection {
                 final DeploymentManager deploymentManager = DeploymentManager.Factory.create(client);
                 deploymentManager.forceDeploy(deployment);
                 if (afterDeployment != null) {
-                    commandExecutor.execute(client, wildflyPath, afterDeployment);
+                    commandExecutor.execute(configuration, wildflyPath, afterDeployment);
                 }
             }
             try {

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <version.org.jboss.logmanager>2.0.4.Final</version.org.jboss.logmanager>
         <version.org.wildfly.checkstyle-config>1.0.5.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.common.wildfly-common>1.2.0.Beta10</version.org.wildfly.common.wildfly-common>
-        <version.org.wildfly.core>3.0.0.Beta21</version.org.wildfly.core>
+        <version.org.wildfly.core>3.0.0.Beta27</version.org.wildfly.core>
         <version.org.wildfly.dist>10.1.0.Final</version.org.wildfly.dist>
 
         <!-- maven dependencies -->


### PR DESCRIPTION
…rollerClient to be used. Rather than attempting to implement this interface, just change the CommandContext to internally use it's own ModelControllerClient.

https://issues.jboss.org/browse/WFMP-69