### PR TITLE
WFMP-84 fix NPE when using path-elements for modulesPath

### DIFF
--- a/plugin/src/main/java/org/wildfly/plugin/server/ModulesPath.java
+++ b/plugin/src/main/java/org/wildfly/plugin/server/ModulesPath.java
@@ -51,7 +51,9 @@ public class ModulesPath {
             return Collections.emptyList();
         }
         final Collection<String> result = new ArrayList<>();
-        result.add(modulePath.getAbsolutePath());
+        if (modulePath != null) {
+            result.add(modulePath.getAbsolutePath());
+        }
         if (paths != null) {
             for (File path : paths) {
                 result.add(path.getAbsolutePath());


### PR DESCRIPTION
See [WFMP-84](https://issues.jboss.org/browse/WFMP-84) for further explanation.