### PR TITLE
[WFMP-86] If fail-on-error is set to false log a warning message for …

### DIFF
--- a/plugin/src/main/java/org/wildfly/plugin/cli/ExecuteCommandsMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/cli/ExecuteCommandsMojo.java
@@ -212,7 +212,11 @@ public class ExecuteCommandsMojo extends AbstractServerConnection {
                         default:
                             msg.append("Reason unknown");
                     }
-                    throw new MojoExecutionException(msg.toString());
+                    if (failOnError) {
+                        throw new MojoExecutionException(msg.toString());
+                    } else {
+                        getLog().warn(msg);
+                    }
                 }
             } catch (IOException e) {
                 throw new MojoFailureException("Failed to execute scripts.", e);


### PR DESCRIPTION
…offline CLI rather than throw an exception.

https://issues.jboss.org/browse/WFMP-86