### PR TITLE
[WFMP-93] Change the java-opts configuration in the execute-commands …

### DIFF
--- a/plugin/src/main/java/org/wildfly/plugin/cli/ExecuteCommandsMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/cli/ExecuteCommandsMojo.java
@@ -166,7 +166,7 @@ public class ExecuteCommandsMojo extends AbstractServerConnection {
      * {@code true}.
      */
     @Parameter(alias = "java-opts", property = PropertyNames.JAVA_OPTS)
-    private String javaOpts;
+    private String[] javaOpts;
 
     @Inject
     private CommandExecutor commandExecutor;
@@ -194,11 +194,7 @@ public class ExecuteCommandsMojo extends AbstractServerConnection {
             try {
                 final StandardOutput out = StandardOutput.parse(stdout, false);
 
-                String[] opts = null;
-                if (javaOpts != null) {
-                    opts = javaOpts.split("[\\n\\s]+");
-                }
-                final int exitCode = offlineCLIExecutor.execute(jbossHome, getCommands(), out, systemProperties, opts);
+                final int exitCode = offlineCLIExecutor.execute(jbossHome, getCommands(), out, systemProperties, javaOpts);
                 if (exitCode != 0) {
                     final StringBuilder msg = new StringBuilder("Failed to execute commands: ");
                     switch (out.getTarget()) {
@@ -263,6 +259,18 @@ public class ExecuteCommandsMojo extends AbstractServerConnection {
             } finally {
                 System.setProperties(currentSystemProperties);
             }
+        }
+    }
+
+    /**
+     * Allows the {@link #javaOpts} to be set as a string. The string is assumed to be space delimited.
+     *
+     * @param value a spaced delimited value of JVM options
+     */
+    @SuppressWarnings("unused")
+    public void setJavaOpts(final String value) {
+        if (value != null) {
+            javaOpts = value.split("\\s+");
         }
     }
 

--- a/plugin/src/main/java/org/wildfly/plugin/server/RunMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/server/RunMojo.java
@@ -336,6 +336,18 @@ public class RunMojo extends AbstractServerConnection {
         }
     }
 
+    /**
+     * Allows the {@link #javaOpts} to be set as a string. The string is assumed to be space delimited.
+     *
+     * @param value a spaced delimited value of JVM options
+     */
+    @SuppressWarnings("unused")
+    public void setJavaOpts(final String value) {
+        if (value != null) {
+            javaOpts = value.split("\\s+");
+        }
+    }
+
     private StandaloneCommandBuilder createCommandBuilder(final Path wildflyPath) {
         final StandaloneCommandBuilder commandBuilder = StandaloneCommandBuilder.of(wildflyPath)
                 .setJavaHome(javaHome)

--- a/plugin/src/main/java/org/wildfly/plugin/server/StartMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/server/StartMojo.java
@@ -301,6 +301,18 @@ public class StartMojo extends AbstractServerConnection {
         }
     }
 
+    /**
+     * Allows the {@link #javaOpts} to be set as a string. The string is assumed to be space delimited.
+     *
+     * @param value a spaced delimited value of JVM options
+     */
+    @SuppressWarnings("unused")
+    public void setJavaOpts(final String value) {
+        if (value != null) {
+            javaOpts = value.split("\\s+");
+        }
+    }
+
     private CommandBuilder createCommandBuilder(final Path jbossHome) throws MojoExecutionException {
         if (serverType == ServerType.DOMAIN) {
             return createDomainCommandBuilder(jbossHome);

--- a/plugin/src/site/apt/examples/execute-commands-example.apt.vm
+++ b/plugin/src/site/apt/examples/execute-commands-example.apt.vm
@@ -84,7 +84,54 @@ run-batch
 
 * Execute offline embedded CLI scripts
 
-  The example below shows how to execute commands offline from a CLI script, which is useful for running scripts that embed server or host controller.
+  The example below shows how to execute commands offline from a CLI script, which is useful for running scripts that
+  embed server or host controller.
+
+----------
+<project>
+    ...
+    <build>
+        ...
+        <plugins>
+            ...
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>${version.org.wildfly.plugin}</version>
+                <configuration>
+                    <!-- Tells plugin to start in offline mode, to not try to connect to server or start it-->
+                    <offline>true</offline>
+                    <commands>
+                        <command>/system-property=org.jboss.example.runtime:write-attribute(name=dev)</command>
+                    </commands>
+                    <jboss-home>${wildfly.dir}</jboss-home>
+                    <!-- where to out log-->
+                    <stdout>${project.build.directory}/wildfly-plugin.log</stdout>
+                    <!-- java opts with which CLI is started with -->
+                    <java-opts>
+                        <java-opt>--add-modules=javax.se</java-opt>
+                        <java-opt>-Xmx256m</java-opt>
+                    </java-opts>
+                    <!-- system properties that can than be referenced in CLI script-->
+                    <system-properties>
+                        <public.ip>${node0}</public.ip>
+                    </system-properties>
+                </configuration>
+            </plugin>
+            ...
+        </plugins>
+        ...
+    </build>
+    ...
+</project>
+----------
+
+
+* Execute offline embedded CLI scripts
+
+  The example below shows how to execute commands offline from a CLI script, which is useful for running scripts that
+  embed server or host controller. Note that the <<<java-opts>>> in this example shows how to set JVM options with a
+  space delimited set of options rather than an array.
 
 ----------
 <project>


### PR DESCRIPTION
…goal to be an array to match the start and run goals. Allow the execute-commands, run and start goals to allow for a space delimited <java-opts/> argument.

https://issues.jboss.org/browse/WFMP-93