### PR TITLE
Add include-packagings property to whitelist package types.

### DIFF
--- a/plugin/src/main/java/org/wildfly/plugin/common/PropertyNames.java
+++ b/plugin/src/main/java/org/wildfly/plugin/common/PropertyNames.java
@@ -57,6 +57,8 @@ public interface PropertyNames {
 
     String ID = "wildfly.id";
 
+    String INCLUDE_PACKAGINGS = "wildfly.includePackagings";
+
     String IGNORE_MISSING_DEPLOYMENT = "undeploy.ignoreMissingDeployment";
 
     String JAVA_HOME = "java.home";


### PR DESCRIPTION
Sometimes, deploying all jars is not desired. Also, there may be additional packaing types such as maven-archetype which should not be processed. Therefore, I have created a whitelist property to define which packaging types should be included. It is defined as a comma separated String property to make it usable from CLI.