### PR TITLE
[WFMP-130] Deprecate parameters that refer to downloading a Maven artifact for the server. These will be removed in 3.0.0.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: WildFly Maven Plugin - CI
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+
+jobs:
+  build:
+    name: ${{ matrix.os }}-jdk${{ matrix.java }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest ]
+        java: ['8', '11']
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v2
+        with:
+          java-version: ${{ matrix.java }}
+          cache: 'maven'
+          distribution: 'temurin'
+      - name: Build and Test on ${{ matrix.java }}
+        run: mvn clean install '-Dorg.jboss.logmanager.nocolor=true'
+      - name: Upload surefire logs for failed run
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: surefire-reports-${{ matrix.os }}-${{ matrix.java }}
+          path: '**/surefire-reports/*.txt'
+      - name: Upload failsafe logs for failed run
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: failsafe-reports-${{ matrix.os }}-${{ matrix.java }}
+          path: '**/failsafe-reports/*.txt'
+      - name: Upload logs for failed run
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: server-logs-${{ matrix.os }}-${{ matrix.java }}
+          path: '**/*.log'

--- a/plugin/src/main/java/org/wildfly/plugin/cli/ExecuteCommandsMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/cli/ExecuteCommandsMojo.java
@@ -126,6 +126,10 @@ public class ExecuteCommandsMojo extends AbstractServerConnection {
      * <p>
      * Note that if {@code offline} is set to {@code true} this setting really has no effect.
      * </p>
+     * <p>
+     * <strong>WARNING: </strong> In 3.0.0 you'll be required to set the {@code jboss-home}. An error will occur if
+     * this option is {@code true} and the {@code jboss-home} is not set.
+     * </p>
      *
      * @since 2.0.0
      */
@@ -230,6 +234,8 @@ public class ExecuteCommandsMojo extends AbstractServerConnection {
             //we do not need to download WildFly
             return Paths.get(jbossHome);
         }
+        getLog().warn("The jboss-home parameter was not set. In 3.0.0 this parameter will be required. " +
+                "Downloading a server via Maven artifact will not longer be supported.");
         final Path result = artifactResolver.resolve(session, repositories, ArtifactNameBuilder.forRuntime(null).build());
         try {
             return Archives.uncompress(result, buildDir.toPath());

--- a/plugin/src/main/java/org/wildfly/plugin/server/RunMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/server/RunMojo.java
@@ -72,6 +72,7 @@ import org.wildfly.plugin.repository.ArtifactResolver;
  */
 @Mojo(name = "run", requiresDependencyResolution = ResolutionScope.RUNTIME)
 @Execute(phase = LifecyclePhase.PACKAGE)
+@SuppressWarnings("DeprecatedIsStillUsed")
 public class RunMojo extends AbstractServerConnection {
 
     @Parameter(defaultValue = "${project}", readonly = true, required = true)
@@ -95,33 +96,48 @@ public class RunMojo extends AbstractServerConnection {
     /**
      * A string of the form groupId:artifactId:version[:packaging][:classifier]. Any missing portion of the artifact
      * will be replaced with the it's appropriate default property value
+     *
+     * @deprecated this will be removed in 3.0.0 in favor of provisioning a server
      */
+    @Deprecated
     @Parameter(property = PropertyNames.WILDFLY_ARTIFACT)
     private String artifact;
 
     /**
      * The {@code groupId} of the artifact to download. Ignored if {@link #artifact} {@code groupId} portion is used.
+     *
+     * @deprecated this will be removed in 3.0.0 in favor of provisioning a server
      */
+    @Deprecated
     @Parameter(defaultValue = ArtifactNameBuilder.WILDFLY_GROUP_ID, property = PropertyNames.WILDFLY_GROUP_ID)
     private String groupId;
 
     /**
      * The {@code artifactId} of the artifact to download. Ignored if {@link #artifact} {@code artifactId} portion is
      * used.
+     *
+     * @deprecated this will be removed in 3.0.0 in favor of provisioning a server
      */
+    @Deprecated
     @Parameter(defaultValue = ArtifactNameBuilder.WILDFLY_ARTIFACT_ID, property = PropertyNames.WILDFLY_ARTIFACT_ID)
     private String artifactId;
 
     /**
      * The {@code classifier} of the artifact to download. Ignored if {@link #artifact} {@code classifier} portion is
      * used.
+     *
+     * @deprecated this will be removed in 3.0.0 in favor of provisioning a server
      */
+    @Deprecated
     @Parameter(property = PropertyNames.WILDFLY_CLASSIFIER)
     private String classifier;
 
     /**
      * The {@code packaging} of the artifact to download. Ignored if {@link #artifact} {@code packing} portion is used.
+     *
+     * @deprecated this will be removed in 3.0.0 in favor of provisioning a server
      */
+    @Deprecated
     @Parameter(property = PropertyNames.WILDFLY_PACKAGING, defaultValue = ArtifactNameBuilder.WILDFLY_PACKAGING)
     private String packaging;
 
@@ -244,7 +260,10 @@ public class RunMojo extends AbstractServerConnection {
     /**
      * By default certain package types are ignored when processing, e.g. {@code maven-project} and {@code pom}. Set
      * this value to {@code false} if this check should be bypassed.
+     *
+     * @deprecated this will be removed in 3.0.0 as the value is never used
      */
+    @Deprecated
     @Parameter(alias = "check-packaging", property = PropertyNames.CHECK_PACKAGING, defaultValue = "true")
     private boolean checkPackaging;
 

--- a/plugin/src/main/java/org/wildfly/plugin/server/StartMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/server/StartMojo.java
@@ -63,6 +63,7 @@ import org.wildfly.plugin.repository.ArtifactResolver;
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
 @Mojo(name = "start", requiresDependencyResolution = ResolutionScope.RUNTIME)
+@SuppressWarnings("DeprecatedIsStillUsed")
 public class StartMojo extends AbstractServerConnection {
 
     @Parameter(defaultValue = "${repositorySystemSession}", readonly = true, required = true)
@@ -89,33 +90,48 @@ public class StartMojo extends AbstractServerConnection {
     /**
      * A string of the form groupId:artifactId:version[:packaging][:classifier]. Any missing portion of the artifact
      * will be replaced with the it's appropriate default property value
+     *
+     * @deprecated this will be removed in 3.0.0 in favor of provisioning a server
      */
+    @Deprecated
     @Parameter(property = PropertyNames.WILDFLY_ARTIFACT)
     private String artifact;
 
     /**
      * The {@code groupId} of the artifact to download. Ignored if {@link #artifact} {@code groupId} portion is used.
+     *
+     * @deprecated this will be removed in 3.0.0 in favor of provisioning a server
      */
+    @Deprecated
     @Parameter(defaultValue = ArtifactNameBuilder.WILDFLY_GROUP_ID, property = PropertyNames.WILDFLY_GROUP_ID)
     private String groupId;
 
     /**
      * The {@code artifactId} of the artifact to download. Ignored if {@link #artifact} {@code artifactId} portion is
      * used.
+     *
+     * @deprecated this will be removed in 3.0.0 in favor of provisioning a server
      */
+    @Deprecated
     @Parameter(defaultValue = ArtifactNameBuilder.WILDFLY_ARTIFACT_ID, property = PropertyNames.WILDFLY_ARTIFACT_ID)
     private String artifactId;
 
     /**
      * The {@code classifier} of the artifact to download. Ignored if {@link #artifact} {@code classifier} portion is
      * used.
+     *
+     * @deprecated this will be removed in 3.0.0 in favor of provisioning a server
      */
+    @Deprecated
     @Parameter(property = PropertyNames.WILDFLY_CLASSIFIER)
     private String classifier;
 
     /**
      * The {@code packaging} of the artifact to download. Ignored if {@link #artifact} {@code packing} portion is used.
+     *
+     * @deprecated this will be removed in 3.0.0 in favor of provisioning a server
      */
+    @Deprecated
     @Parameter(property = PropertyNames.WILDFLY_PACKAGING, defaultValue = ArtifactNameBuilder.WILDFLY_PACKAGING)
     private String packaging;
 

--- a/plugin/src/site/fml/faq.fml
+++ b/plugin/src/site/fml/faq.fml
@@ -107,5 +107,15 @@
                 </p>
             </answer>
         </faq>
+        <faq id="zipDownload">
+            <question>Why are archived server downloads being deprecated?</question>
+            <answer>
+                <p>
+                    In 3.0.0 new goals will be introduced to allow provisioning a server. WildFly Galleon has come a long
+                    way and it is the preferred means of creating a server. For this reason, the downloading of a server
+                    by means of a Maven artifact will be removed in 3.0.0.
+                </p>
+            </answer>
+        </faq>
     </part>
 </faqs>

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
         <version.org.wildfly.checkstyle-config>1.0.7.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.common.wildfly-common>1.5.1.Final</version.org.wildfly.common.wildfly-common>
         <version.org.wildfly.core>9.0.1.Final</version.org.wildfly.core>
-        <version.org.wildfly.dist>14.0.1.Final</version.org.wildfly.dist>
+        <version.org.wildfly.dist>24.0.1.Final</version.org.wildfly.dist>
 
         <!-- maven dependencies -->
         <version.javax.inject.javax.inject>1</version.javax.inject.javax.inject>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFMP-130

Also https://issues.redhat.com/browse/WFMP-132