### PR TITLE
Fix for WFMP-145, Introduce an offline CLI command executor

### DIFF
--- a/core/src/main/java/org/wildfly/plugin/core/ServerHelper.java
+++ b/core/src/main/java/org/wildfly/plugin/core/ServerHelper.java
@@ -23,7 +23,6 @@ import static org.jboss.as.controller.client.helpers.ClientConstants.CONTROLLER_
 import static org.jboss.as.controller.client.helpers.ClientConstants.CONTROLLER_PROCESS_STATE_STOPPING;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
@@ -64,10 +63,7 @@ public class ServerHelper {
      * @return {@code true} if the path is valid otherwise {@code false}
      */
     public static boolean isValidHomeDirectory(final Path path) {
-        return path != null
-                && Files.exists(path)
-                && Files.isDirectory(path)
-                && Files.exists(path.resolve("jboss-modules.jar"));
+        return Utils.isValidHomeDirectory(path);
     }
 
     /**

--- a/core/src/main/java/org/wildfly/plugin/core/Utils.java
+++ b/core/src/main/java/org/wildfly/plugin/core/Utils.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.plugin.core;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+public class Utils {
+
+    public static boolean isValidHomeDirectory(final Path path) {
+        return path != null
+                && Files.exists(path)
+                && Files.isDirectory(path)
+                && Files.exists(path.resolve("jboss-modules.jar"));
+    }
+}

--- a/plugin/src/main/java/org/wildfly/plugin/cli/AbstractCommandExecutor.java
+++ b/plugin/src/main/java/org/wildfly/plugin/cli/AbstractCommandExecutor.java
@@ -1,0 +1,198 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2022 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.plugin.cli;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.codehaus.plexus.logging.AbstractLogEnabled;
+import org.codehaus.plexus.logging.Logger;
+import org.jboss.galleon.universe.maven.repo.MavenRepoManager;
+import org.wildfly.core.launcher.CliCommandBuilder;
+import org.wildfly.core.launcher.Launcher;
+import org.wildfly.plugin.common.Environment;
+import org.wildfly.plugin.common.StandardOutput;
+import static org.wildfly.plugin.core.Constants.CLI_RESOLVE_PARAMETERS_VALUES;
+
+/**
+ * An abstract command executor for executing CLI commands.
+ *
+ * @author jdenise@redhat.com
+ */
+public abstract class AbstractCommandExecutor<T extends BaseCommandConfiguration> extends AbstractLogEnabled {
+
+    /**
+     * Executes CLI commands based on the configuration.
+     *
+     * @param config the configuration used to execute the CLI commands
+     * @param artifactResolver Resolver to retrieve CLI artifact for in-process execution.
+     *
+     * @throws MojoFailureException   if the JBoss Home directory is required and invalid
+     * @throws MojoExecutionException if an error occurs executing the CLI commands
+     */
+    public abstract void execute(final T config, MavenRepoManager artifactResolver) throws MojoFailureException, MojoExecutionException;
+    protected abstract int executeInNewProcess(final T config, final Path scriptFile, final StandardOutput stdout) throws MojoExecutionException, IOException;
+
+    protected void executeInNewProcess(final T config) throws MojoExecutionException {
+        // If we have commands create a script file and execute
+        if (!config.getCommands().isEmpty()) {
+            Path scriptFile = null;
+            try {
+                scriptFile = ScriptWriter.create(config);
+                executeInNewProcess(config, scriptFile);
+            } catch (IOException e) {
+                throw new MojoExecutionException("Failed execute commands.", e);
+            } finally {
+                if (scriptFile != null) {
+                    try {
+                        Files.deleteIfExists(scriptFile);
+                    } catch (IOException e) {
+                        getLogger().debug("Failed to deleted CLI script file: " + scriptFile, e);
+                    }
+                }
+            }
+        }
+        if (!config.getScripts().isEmpty()) {
+            for (Path script : config.getScripts()) {
+                executeInNewProcess(config, script);
+            }
+        }
+    }
+
+    private void executeInNewProcess(final T config, final Path scriptFile) throws MojoExecutionException {
+        getLogger().debug("Executing CLI scripts");
+        try {
+            final StandardOutput out = StandardOutput.parse(config.getStdout(), false, config.isAppend());
+
+            final int exitCode = executeInNewProcess(config, scriptFile, out);
+            if (exitCode != 0) {
+                final StringBuilder msg = new StringBuilder("Failed to execute commands: ");
+                switch (out.getTarget()) {
+                    case COLLECTING:
+                        msg.append(out);
+                        break;
+                    case FILE:
+                        final Path stdoutPath = out.getStdoutPath();
+                        msg.append("See ").append(stdoutPath).append(" for full details of failure.").append(System.lineSeparator());
+                        final List<String> lines = Files.readAllLines(stdoutPath);
+                        lines.subList(Math.max(lines.size() - 4, 0), lines.size())
+                                .forEach(line -> msg.append(line).append(System.lineSeparator()));
+                        break;
+                    case SYSTEM_ERR:
+                    case SYSTEM_OUT:
+                    case INHERIT:
+                        msg.append("See previous messages for failure messages.");
+                        break;
+                    default:
+                        msg.append("Reason unknown");
+                }
+                if (config.isFailOnError()) {
+                    throw new MojoExecutionException(msg.toString());
+                } else {
+                    getLogger().warn(msg.toString());
+                }
+            }
+        } catch (IOException e) {
+            throw new MojoExecutionException("Failed to execute scripts.", e);
+        }
+    }
+
+    protected CliCommandBuilder createCommandBuilder(final T config, final Path scriptFile) throws IOException {
+        final Logger log = getLogger();
+        final CliCommandBuilder builder = CliCommandBuilder.of(config.getJBossHome())
+                .setScriptFile(scriptFile)
+                .addCliArguments(config.getCLIArguments())
+                .setTimeout(config.getTimeout() * 1000);
+
+        // Workaround for WFCORE-4121
+        if (Environment.isModularJvm(builder.getJavaHome())) {
+            builder.addJavaOptions(Environment.getModularJvmArguments());
+        }
+        final Map<String, String> systemProperties = config.getSystemProperties();
+        systemProperties.forEach((key, value) -> builder.addJavaOption(String.format("-D%s=%s", key, value)));
+        if (systemProperties.containsKey("module.path")) {
+            builder.setModuleDirs(systemProperties.get("module.path"));
+        }
+
+        final Properties properties = new Properties();
+        for (Path file : config.getPropertiesFiles()) {
+            parseProperties(file, properties);
+        }
+        for (String key : properties.stringPropertyNames()) {
+            builder.addJavaOption(String.format("-D%s=%s", key, properties.getProperty(key)));
+        }
+
+        final Collection<String> javaOpts = config.getJvmOptions();
+        if (log.isDebugEnabled() && !javaOpts.isEmpty()) {
+            log.debug("java opts: " + javaOpts);
+        }
+        for (String opt : javaOpts) {
+            if (!opt.trim().isEmpty()) {
+                builder.addJavaOption(opt);
+            }
+        }
+        if (config.isExpressionResolved()) {
+            builder.addCliArgument(CLI_RESOLVE_PARAMETERS_VALUES);
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("process parameters: " + builder.build());
+        }
+        return builder;
+    }
+
+    protected int launchProcess(CliCommandBuilder builder, final T config,
+            final StandardOutput stdout) throws MojoExecutionException, IOException {
+        final Logger log = getLogger();
+
+        final Launcher launcher = Launcher.of(builder)
+                .addEnvironmentVariable("JBOSS_HOME", config.getJBossHome().toString())
+                .setRedirectErrorStream(true);
+        stdout.getRedirect().ifPresent(launcher::redirectOutput);
+        final Process process = launcher.launch();
+        final Optional<Thread> consoleConsumer = stdout.startConsumer(process);
+        try {
+            return process.waitFor();
+        } catch (InterruptedException e) {
+            throw new MojoExecutionException("Failed to run goal execute-commands in forked process.", e);
+        } finally {
+            // Be safe and destroy the process to ensure we don't leave rouge processes running
+            if (process.isAlive()) {
+                process.destroyForcibly();
+            }
+            consoleConsumer.ifPresent(Thread::interrupt);
+        }
+    }
+
+    static void parseProperties(final Path file, final Properties properties) throws IOException {
+        try (BufferedReader reader = Files.newBufferedReader(file, StandardCharsets.UTF_8)) {
+            properties.load(reader);
+        }
+    }
+}

--- a/plugin/src/main/java/org/wildfly/plugin/cli/BaseCommandConfiguration.java
+++ b/plugin/src/main/java/org/wildfly/plugin/cli/BaseCommandConfiguration.java
@@ -1,0 +1,410 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2022 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.plugin.cli;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * The configuration used to execute forked offline CLI commands.
+ *
+ * @author jdenise@redhat.com
+ */
+public class BaseCommandConfiguration {
+
+    private final Collection<String> jvmOptions;
+    private final Collection<String> cliArguments;
+    private final Collection<String> commands;
+    private final Map<String, String> systemProperties;
+    private final Collection<Path> propertiesFiles;
+    private final Collection<Path> scripts;
+    private final boolean batch;
+    private final boolean failOnError;
+    private final Path jbossHome;
+    private final String stdout;
+    private final int timeout;
+    private final boolean append;
+    private final boolean resolveExpression;
+
+    protected abstract static class AbstractBuilder<T extends AbstractBuilder<T>> {
+
+        private final Collection<String> jvmOptions = new ArrayList<>();
+        private final Collection<String> cliArguments = new ArrayList<>();
+        private final Collection<String> commands = new ArrayList<>();
+        private final Map<String, String> systemProperties = new LinkedHashMap<>();
+        private final Collection<Path> propertiesFiles = new ArrayList<>();
+        private final Collection<Path> scripts = new ArrayList<>();
+        private boolean batch;
+        private boolean failOnError = true;
+        private Path jbossHome;
+        private String stdout;
+        private int timeout;
+        private boolean append;
+        private boolean resolveExpression;
+
+        protected abstract T builderInstance();
+
+        /**
+         * If true append output to file, otherwise a new file is created.
+         *
+         * @param append true to append to the file.
+         * @return this
+         */
+        public T setAppend(boolean append) {
+            this.append = append;
+            return builderInstance();
+        }
+
+        /**
+         * Sets whether or not the commands should be executed in a batch or
+         * not.
+         *
+         * @param batch {@code true} if the commands should be executed in a
+         * batch, otherwise {@code false}
+         *
+         * @return this configuration
+         */
+        public T setBatch(final boolean batch) {
+            this.batch = batch;
+            return builderInstance();
+        }
+
+        /**
+         * Sets the JBoss Home directory.
+         *
+         * @param jbossHome the JBoss Home directory or {@code null} if the
+         * value is not required
+         *
+         * @return this configuration
+         */
+        public T setJBossHome(final String jbossHome) {
+            if (jbossHome == null) {
+                this.jbossHome = null;
+            } else {
+                this.jbossHome = Paths.get(jbossHome);
+            }
+            return builderInstance();
+        }
+
+        /**
+         * Sets the JBoss Home directory.
+         *
+         * @param jbossHome the JBoss Home directory or {@code null} if the
+         * value is not required
+         *
+         * @return this configuration
+         */
+        public T setJBossHome(final Path jbossHome) {
+            this.jbossHome = jbossHome;
+            return builderInstance();
+        }
+
+        /**
+         * Adds the JVM options used if {@link #isFork()} or
+         * {@link #isOffline()} is set to {@code true}.
+         *
+         * @param jvmOptions the JVM options or {@code null}
+         *
+         * @return this configuration
+         */
+        public T addJvmOptions(final String... jvmOptions) {
+            if (jvmOptions != null) {
+                Collections.addAll(this.jvmOptions, jvmOptions);
+            }
+            return builderInstance();
+        }
+
+        /**
+         * Adds the CLI arguments used if {@link #isFork()} or
+         * {@link #isOffline()} is set to {@code true}.
+         *
+         * @param arguments the CLI arguments or {@code null}
+         *
+         * @return this configuration
+         */
+        public T addCLIArguments(final String... arguments) {
+            if (arguments != null) {
+                Collections.addAll(this.cliArguments, arguments);
+            }
+            return builderInstance();
+        }
+
+        /**
+         * Adds to the system properties to set before the CLI commands are
+         * executed.
+         *
+         * @param systemProperties the system properties or {@code null}
+         *
+         * @return this configuration
+         */
+        public T addSystemProperties(final Map<String, String> systemProperties) {
+            if (systemProperties != null) {
+                this.systemProperties.putAll(systemProperties);
+            }
+            return builderInstance();
+        }
+
+        /**
+         * Adds the properties files to use when executing CLI scripts or
+         * commands.
+         *
+         * @param propertiesFiles the property files to add
+         *
+         * @return this configuration
+         */
+        public T addPropertiesFiles(final Collection<File> propertiesFiles) {
+            propertiesFiles.forEach(f -> this.propertiesFiles.add(f.toPath()));
+            return builderInstance();
+        }
+
+        /**
+         * Adds the commands to the CLI commands that should be executed.
+         *
+         * @param commands the commands to be executed
+         *
+         * @return this configuration
+         */
+        public T addCommands(final Collection<String> commands) {
+            if (commands != null) {
+                this.commands.addAll(commands);
+            }
+            return builderInstance();
+        }
+
+        /**
+         * Adds the scripts to be executed.
+         *
+         * @param scripts the scripts to be executed
+         *
+         * @return this configuration
+         */
+        public T addScripts(final Collection<File> scripts) {
+            scripts.forEach(f -> this.scripts.add(f.toPath()));
+            return builderInstance();
+        }
+
+        /**
+         * Sets whether or not CLI commands should fail if the command ends in
+         * an error or not.
+         *
+         * @param failOnError {@code true} if a CLI command fails then the
+         * execution should fail
+         *
+         * @return this configuration
+         */
+        public T setFailOnError(final boolean failOnError) {
+            this.failOnError = failOnError;
+            return builderInstance();
+        }
+
+        /**
+         * Sets how the standard output stream should be handled if
+         * {@link #isFork()} or {@link #isOffline()} is set to {@code true}.
+         *
+         * @param stdout the pattern for standard out
+         *
+         * @return this configuration
+         */
+        public T setStdout(final String stdout) {
+            this.stdout = stdout;
+            return builderInstance();
+        }
+
+        /**
+         * Sets the timeout, in seconds, used for the management client
+         * connection.
+         *
+         * @param timeout the timeout to use in seconds
+         *
+         * @return this configuration
+         */
+        public T setTimeout(final int timeout) {
+            this.timeout = timeout;
+            return builderInstance();
+        }
+
+        /**
+         * If true resolve expression prior to send the operation to the server
+         *
+         * @param resolveExpression
+         * @return this
+         */
+        public T setResolveExpression(boolean resolveExpression) {
+            this.resolveExpression = resolveExpression;
+            return builderInstance();
+        }
+
+        public BaseCommandConfiguration build() {
+            return new BaseCommandConfiguration(this);
+        }
+    }
+
+    public static class Builder extends AbstractBuilder<Builder> {
+
+        @Override
+        protected Builder builderInstance() {
+            return this;
+        }
+    }
+
+    protected BaseCommandConfiguration(AbstractBuilder<?> builder) {
+        jvmOptions = builder.jvmOptions;
+        commands = builder.commands;
+        systemProperties = builder.systemProperties;
+        propertiesFiles = builder.propertiesFiles;
+        scripts = builder.scripts;
+        cliArguments = builder.cliArguments;
+        batch = builder.batch;
+        failOnError = builder.failOnError;
+        jbossHome = builder.jbossHome;
+        stdout = builder.stdout;
+        timeout = builder.timeout;
+        append = builder.append;
+        resolveExpression = builder.resolveExpression;
+    }
+
+    /**
+     * Is output appended to file.
+     * @return true to append to the file
+     */
+    public boolean isAppend() {
+        return append;
+    }
+
+    /**
+     * Indicates whether or not the commands should be run in a batch or not.
+     *
+     * @return {@code true} if the commands should be executed in a batch,
+     * otherwise {@code false}
+     */
+    public boolean isBatch() {
+        return batch;
+    }
+
+    /**
+     * Returns the JBoss Home directory.
+     *
+     * @return the JBoss Home directory or {@code null} if the value was not set
+     */
+    public Path getJBossHome() {
+        return jbossHome;
+    }
+
+    /**
+     * Returns the JVM options used if {@link #isFork()} or {@link #isOffline()}
+     * is set to {@code true}.
+     *
+     * @return the JVM options
+     */
+    public Collection<String> getJvmOptions() {
+        return Collections.unmodifiableCollection(jvmOptions);
+    }
+
+    /**
+     * Returns the CLI arguments used if {@link #isFork()} or
+     * {@link #isOffline()} is set to {@code true}.
+     *
+     * @return the CLI arguments
+     */
+    public Collection<String> getCLIArguments() {
+        return Collections.unmodifiableCollection(cliArguments);
+    }
+
+    /**
+     * Returns the system properties to set before CLI commands are executed.
+     *
+     * @return the system properties to set before CLI commands are executed
+     */
+    public Map<String, String> getSystemProperties() {
+        return Collections.unmodifiableMap(systemProperties);
+    }
+
+    /**
+     * The properties files to use when executing CLI scripts or commands.
+     *
+     * @return the paths to the properties files
+     */
+    public Collection<Path> getPropertiesFiles() {
+        return Collections.unmodifiableCollection(propertiesFiles);
+    }
+
+    /**
+     * Returns the commands to be executed.
+     *
+     * @return the commands to be executed
+     */
+    public Collection<String> getCommands() {
+        return Collections.unmodifiableCollection(commands);
+    }
+
+    /**
+     * Returns the scripts to be executed.
+     *
+     * @return the scripts to be executed
+     */
+    public Collection<Path> getScripts() {
+        return Collections.unmodifiableCollection(scripts);
+    }
+
+
+    /**
+     * Indicates whether or not CLI commands should fail if the command ends in
+     * an error or not.
+     *
+     * @return {@code true} if a CLI command fails then the execution should
+     * fail
+     */
+    public boolean isFailOnError() {
+        return failOnError;
+    }
+
+    /**
+     * The pattern used to determine how standard out is handled for a new CLI
+     * process.
+     *
+     * @return the standard out pattern
+     */
+    public String getStdout() {
+        return stdout;
+    }
+
+    /**
+     * Gets the timeout, in seconds, used for the management connection.
+     *
+     * @return the timeout used for the management connection
+     */
+    public int getTimeout() {
+        return timeout;
+    }
+
+    /**
+     * Is expression resolved.
+     * @return true is expressions are resolved.
+     */
+    public boolean isExpressionResolved() {
+        return resolveExpression;
+    }
+
+}

--- a/plugin/src/main/java/org/wildfly/plugin/cli/CommandConfiguration.java
+++ b/plugin/src/main/java/org/wildfly/plugin/cli/CommandConfiguration.java
@@ -16,17 +16,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.wildfly.plugin.cli;
 
-import java.io.File;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.Map;
 import java.util.function.Supplier;
 
 import org.jboss.as.controller.client.ModelControllerClient;
@@ -37,86 +28,97 @@ import org.wildfly.plugin.common.MavenModelControllerClientConfiguration;
  *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-public class CommandConfiguration {
+public class CommandConfiguration extends BaseCommandConfiguration {
 
-    private final Collection<String> jvmOptions;
-    private final Collection<String> cliArguments;
-    private final Collection<String> commands;
-    private final Map<String, String> systemProperties;
-    private final Collection<Path> propertiesFiles;
-    private final Collection<Path> scripts;
     private final Supplier<ModelControllerClient> client;
     private final Supplier<MavenModelControllerClientConfiguration> clientConfiguration;
-    private boolean batch;
-    private boolean failOnError;
-    private boolean fork;
-    private Path jbossHome;
-    private boolean offline;
-    private String stdout;
-    private int timeout;
-    private boolean append;
-    private boolean resolveExpression;
+    private final boolean fork;
+    private final boolean offline;
 
-    private CommandConfiguration(final Supplier<ModelControllerClient> client,
-                                 final Supplier<MavenModelControllerClientConfiguration> clientConfiguration) {
-        this.client = client;
-        this.clientConfiguration = clientConfiguration;
-        jvmOptions = new ArrayList<>();
-        commands = new ArrayList<>();
-        systemProperties = new LinkedHashMap<>();
-        propertiesFiles = new ArrayList<>();
-        scripts = new ArrayList<>();
-        failOnError = true;
-        cliArguments = new ArrayList<>();
+    protected abstract static class AbstractBuilder<T extends AbstractBuilder<T>> extends BaseCommandConfiguration.AbstractBuilder<T> {
+
+        private final Supplier<ModelControllerClient> client;
+        private final Supplier<MavenModelControllerClientConfiguration> clientConfiguration;
+        private boolean fork;
+        private boolean offline;
+
+        AbstractBuilder(final Supplier<ModelControllerClient> clientSupplier,
+                final Supplier<MavenModelControllerClientConfiguration> clientConfigurationSupplier) {
+            this.client = clientSupplier;
+            this.clientConfiguration = clientConfigurationSupplier;
+        }
+
+        /**
+         * Sets whether or not the commands should be executed in a new process.
+         * <p>
+         * Note that is {@link #isOffline()} is set to {@code true} this has no
+         * effect.
+         * </p>
+         *
+         * @param fork {@code true} if commands should be executed in a new
+         * process
+         *
+         * @return this configuration
+         */
+        public T setFork(final boolean fork) {
+            this.fork = fork;
+            return builderInstance();
+        }
+
+        /**
+         * Sets whether a client should be associated with the CLI context.
+         * <p>
+         * Note this launches CLI in a new process.
+         * </p>
+         *
+         * @param offline {@code true} if this should be an offline process
+         *
+         * @return this configuration
+         */
+        public T setOffline(final boolean offline) {
+            this.offline = offline;
+            return builderInstance();
+        }
+
+        @Override
+        public CommandConfiguration build() {
+            return new CommandConfiguration(this);
+        }
+    }
+
+    public static class Builder extends AbstractBuilder<Builder> {
+
+        Builder(Supplier<ModelControllerClient> clientSupplier,
+                Supplier<MavenModelControllerClientConfiguration> clientConfigurationSupplier) {
+            super(clientSupplier, clientConfigurationSupplier);
+        }
+
+        @Override
+        protected Builder builderInstance() {
+            return this;
+        }
+    }
+
+    protected CommandConfiguration(AbstractBuilder<?> builder) {
+        super(builder);
+        client = builder.client;
+        clientConfiguration = builder.clientConfiguration;
+        fork = builder.fork;
+        offline = builder.offline;
     }
 
     /**
-     * Creates a new command configuration.
+     * Creates a new command configuration Builder.
      *
-     * @param clientSupplier              the supplier used to get a management client
-     * @param clientConfigurationSupplier a supplier used to get the client configuration
+     * @param clientSupplier the supplier used to get a management client
+     * @param clientConfigurationSupplier a supplier used to get the client
+     * configuration
      *
-     * @return a new command configuration
+     * @return a new command configuration Builder.
      */
-    public static CommandConfiguration of(final Supplier<ModelControllerClient> clientSupplier,
-                                          final Supplier<MavenModelControllerClientConfiguration> clientConfigurationSupplier) {
-        return new CommandConfiguration(clientSupplier, clientConfigurationSupplier);
-    }
-
-    /**
-     * Is output appended to file.
-     */
-    public boolean isAppend() {
-        return append;
-    }
-
-    /**
-     * If true append output to file, otherwise a new file is created.
-     */
-    public CommandConfiguration setAppend(boolean append) {
-        this.append = append;
-        return this;
-    }
-
-    /**
-     * Indicates whether or not the commands should be run in a batch or not.
-     *
-     * @return {@code true} if the commands should be executed in a batch, otherwise {@code false}
-     */
-    public boolean isBatch() {
-        return batch;
-    }
-
-    /**
-     * Sets whether or not the commands should be executed in a batch or not.
-     *
-     * @param batch {@code true} if the commands should be executed in a batch, otherwise {@code false}
-     *
-     * @return this configuration
-     */
-    public CommandConfiguration setBatch(final boolean batch) {
-        this.batch = batch;
-        return this;
+    public static Builder of(final Supplier<ModelControllerClient> clientSupplier,
+            final Supplier<MavenModelControllerClientConfiguration> clientConfigurationSupplier) {
+        return new Builder(clientSupplier, clientConfigurationSupplier);
     }
 
     /**
@@ -138,199 +140,8 @@ public class CommandConfiguration {
     }
 
     /**
-     * Returns the JBoss Home directory.
-     *
-     * @return the JBoss Home directory or {@code null} if the value was not set
-     */
-    public Path getJBossHome() {
-        return jbossHome;
-    }
-
-    /**
-     * Sets the JBoss Home directory.
-     *
-     * @param jbossHome the JBoss Home directory or {@code null} if the value is not required
-     *
-     * @return this configuration
-     */
-    public CommandConfiguration setJBossHome(final String jbossHome) {
-        if (jbossHome == null) {
-            this.jbossHome = null;
-        } else {
-            this.jbossHome = Paths.get(jbossHome);
-        }
-        return this;
-    }
-
-    /**
-     * Sets the JBoss Home directory.
-     *
-     * @param jbossHome the JBoss Home directory or {@code null} if the value is not required
-     *
-     * @return this configuration
-     */
-    public CommandConfiguration setJBossHome(final Path jbossHome) {
-        this.jbossHome = jbossHome;
-        return this;
-    }
-
-    /**
-     * Returns the JVM options used if {@link #isFork()} or {@link #isOffline()} is set to {@code true}.
-     *
-     * @return the JVM options
-     */
-    public Collection<String> getJvmOptions() {
-        return Collections.unmodifiableCollection(jvmOptions);
-    }
-
-    /**
-     * Adds the JVM options used if {@link #isFork()} or {@link #isOffline()} is set to {@code true}.
-     *
-     * @param jvmOptions the JVM options or {@code null}
-     *
-     * @return this configuration
-     */
-    public CommandConfiguration addJvmOptions(final String... jvmOptions) {
-        if (jvmOptions != null) {
-            Collections.addAll(this.jvmOptions, jvmOptions);
-        }
-        return this;
-    }
-
-    /**
-     * Returns the CLI arguments used if {@link #isFork()} or {@link #isOffline()} is set to {@code true}.
-     *
-     * @return the CLI arguments
-     */
-    public Collection<String> getCLIArguments() {
-        return Collections.unmodifiableCollection(cliArguments);
-    }
-
-    /**
-     * Adds the CLI arguments used if {@link #isFork()} or {@link #isOffline()} is set to {@code true}.
-     *
-     * @param arguments the CLI arguments or {@code null}
-     *
-     * @return this configuration
-     */
-    public CommandConfiguration addCLIArguments(final String... arguments) {
-        if (arguments != null) {
-            Collections.addAll(this.cliArguments, arguments);
-        }
-        return this;
-    }
-
-    /**
-     * Returns the system properties to set before CLI commands are executed.
-     *
-     * @return the system properties to set before CLI commands are executed
-     */
-    public Map<String, String> getSystemProperties() {
-        return Collections.unmodifiableMap(systemProperties);
-    }
-
-    /**
-     * Adds to the system properties to set before the CLI commands are executed.
-     *
-     * @param systemProperties the system properties or {@code null}
-     *
-     * @return this configuration
-     */
-    public CommandConfiguration addSystemProperties(final Map<String, String> systemProperties) {
-        if (systemProperties != null) {
-            this.systemProperties.putAll(systemProperties);
-        }
-        return this;
-    }
-
-    /**
-     * The properties files to use when executing CLI scripts or commands.
-     *
-     * @return the paths to the properties files
-     */
-    public Collection<Path> getPropertiesFiles() {
-        return Collections.unmodifiableCollection(propertiesFiles);
-    }
-
-    /**
-     * Adds the properties files to use when executing CLI scripts or commands.
-     *
-     * @param propertiesFiles the property files to add
-     *
-     * @return this configuration
-     */
-    public CommandConfiguration addPropertiesFiles(final Collection<File> propertiesFiles) {
-        propertiesFiles.forEach(f -> this.propertiesFiles.add(f.toPath()));
-        return this;
-    }
-
-    /**
-     * Returns the commands to be executed.
-     *
-     * @return the commands to be executed
-     */
-    public Collection<String> getCommands() {
-        return Collections.unmodifiableCollection(commands);
-    }
-
-    /**
-     * Adds the commands to the CLI commands that should be executed.
-     *
-     * @param commands the commands to be executed
-     *
-     * @return this configuration
-     */
-    public CommandConfiguration addCommands(final Collection<String> commands) {
-        if (commands != null) {
-            this.commands.addAll(commands);
-        }
-        return this;
-    }
-
-    /**
-     * Returns the scripts to be executed.
-     *
-     * @return the scripts to be executed
-     */
-    public Collection<Path> getScripts() {
-        return Collections.unmodifiableCollection(scripts);
-    }
-
-    /**
-     * Adds the scripts to be executed.
-     *
-     * @param scripts the scripts to be executed
-     *
-     * @return this configuration
-     */
-    public CommandConfiguration addScripts(final Collection<File> scripts) {
-        scripts.forEach(f -> this.scripts.add(f.toPath()));
-        return this;
-    }
-
-    /**
-     * Indicates whether or not CLI commands should fail if the command ends in an error or not.
-     *
-     * @return {@code true} if a CLI command fails then the execution should fail
-     */
-    public boolean isFailOnError() {
-        return failOnError;
-    }
-
-    /**
-     * Sets whether or not CLI commands should fail if the command ends in an error or not.
-     *
-     * @param failOnError {@code true} if a CLI command fails then the execution should fail
-     *
-     * @return this configuration
-     */
-    public CommandConfiguration setFailOnError(final boolean failOnError) {
-        this.failOnError = failOnError;
-        return this;
-    }
-
-    /**
-     * Indicates whether or not CLI commands should be executed in a new process.
+     * Indicates whether or not CLI commands should be executed in a new
+     * process.
      *
      * @return {@code true} to execute CLI commands in a new process
      */
@@ -339,100 +150,12 @@ public class CommandConfiguration {
     }
 
     /**
-     * Sets whether or not the commands should be executed in a new process.
-     * <p>
-     * Note that is {@link #isOffline()} is set to {@code true} this has no effect.
-     * </p>
-     *
-     * @param fork {@code true} if commands should be executed in a new process
-     *
-     * @return this configuration
-     */
-    public CommandConfiguration setFork(final boolean fork) {
-        this.fork = fork;
-        return this;
-    }
-
-    /**
      * Indicates whether or not this should be an offline process.
      *
-     * @return {@code true} if this should be an offline process, otherwise {@code false}
+     * @return {@code true} if this should be an offline process, otherwise
+     * {@code false}
      */
     public boolean isOffline() {
         return offline;
     }
-
-    /**
-     * Sets whether a client should be associated with the CLI context.
-     * <p>
-     * Note this launches CLI in a new process.
-     * </p>
-     *
-     * @param offline {@code true} if this should be an offline process
-     *
-     * @return this configuration
-     */
-    public CommandConfiguration setOffline(final boolean offline) {
-        this.offline = offline;
-        return this;
-    }
-
-    /**
-     * The pattern used to determine how standard out is handled for a new CLI process.
-     *
-     * @return the standard out pattern
-     */
-    public String getStdout() {
-        return stdout;
-    }
-
-    /**
-     * Sets how the standard output stream should be handled if {@link #isFork()} or {@link #isOffline()} is set to
-     * {@code true}.
-     *
-     * @param stdout the pattern for standard out
-     *
-     * @return this configuration
-     */
-    public CommandConfiguration setStdout(final String stdout) {
-        this.stdout = stdout;
-        return this;
-    }
-
-    /**
-     * Gets the timeout, in seconds, used for the management connection.
-     *
-     * @return the timeout used for the management connection
-     */
-    public int getTimeout() {
-        return timeout;
-    }
-
-    /**
-     * Sets the timeout, in seconds, used for the management client connection.
-     *
-     * @param timeout the timeout to use in seconds
-     *
-     * @return this configuration
-     */
-    public CommandConfiguration setTimeout(final int timeout) {
-        this.timeout = timeout;
-        return this;
-    }
-
-    /**
-     * If true resolve expression prior to send the operation to the server
-     */
-    public CommandConfiguration setResolveExpression(boolean resolveExpression) {
-        this.resolveExpression = resolveExpression;
-        return this;
-    }
-
-    /**
-     * Is expression resolved.
-     */
-    public boolean isExpressionResolved() {
-        return resolveExpression;
-    }
-
 }

--- a/plugin/src/main/java/org/wildfly/plugin/cli/ExecuteCommandsMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/cli/ExecuteCommandsMojo.java
@@ -219,7 +219,7 @@ public class ExecuteCommandsMojo extends AbstractServerConnection {
         }
         MavenRepositoriesEnricher.enrich(mavenSession, project, repositories);
         mavenRepoManager = new MavenArtifactRepositoryManager(repoSystem, session, repositories);
-        final CommandConfiguration cmdConfig = CommandConfiguration.of(this::createClient, this::getClientConfiguration)
+        final CommandConfiguration.Builder cmdConfigBuilder = CommandConfiguration.of(this::createClient, this::getClientConfiguration)
                 .addCommands(commands)
                 .addJvmOptions(javaOpts)
                 .addPropertiesFiles(propertiesFiles)
@@ -235,9 +235,9 @@ public class ExecuteCommandsMojo extends AbstractServerConnection {
                 .setResolveExpression(resolveExpressions);
         // Why is that? fork implies a jboss-home?
         if (fork) {
-            cmdConfig.setJBossHome(getInstallation(buildDir.toPath().resolve(Utils.WILDFLY_DEFAULT_DIR)));
+            cmdConfigBuilder.setJBossHome(getInstallation(buildDir.toPath().resolve(Utils.WILDFLY_DEFAULT_DIR)));
         }
-        commandExecutor.execute(cmdConfig, mavenRepoManager);
+        commandExecutor.execute(cmdConfigBuilder.build(), mavenRepoManager);
     }
 
     /**

--- a/plugin/src/main/java/org/wildfly/plugin/cli/OfflineCommandExecutor.java
+++ b/plugin/src/main/java/org/wildfly/plugin/cli/OfflineCommandExecutor.java
@@ -1,0 +1,65 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2022 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.plugin.cli;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.jboss.galleon.universe.maven.repo.MavenRepoManager;
+import org.wildfly.core.launcher.CliCommandBuilder;
+import org.wildfly.plugin.common.StandardOutput;
+import org.wildfly.plugin.core.Utils;
+
+/**
+ * A command executor for executing offline CLI commands.
+ *
+ * @author jdenise@redhat.com
+ */
+@Singleton
+@Named
+public class OfflineCommandExecutor extends AbstractCommandExecutor<BaseCommandConfiguration> {
+
+    /**
+     * Executes forked offline CLI commands based on the configuration.
+     *
+     * @param config the configuration used to execute the CLI commands
+     * @param artifactResolver Resolver to retrieve CLI artifact for in-process execution.
+     *
+     * @throws MojoFailureException   if the JBoss Home directory is required and invalid
+     * @throws MojoExecutionException if an error occurs executing the CLI commands
+     */
+    @Override
+    public void execute(final BaseCommandConfiguration config, MavenRepoManager artifactResolver) throws MojoFailureException, MojoExecutionException {
+        if (!Utils.isValidHomeDirectory(config.getJBossHome())) {
+            throw new MojoFailureException("Invalid JBoss Home directory is not valid: " + config.getJBossHome());
+        }
+        executeInNewProcess(config);
+    }
+
+    @Override
+    protected int executeInNewProcess(final BaseCommandConfiguration config, final Path scriptFile, final StandardOutput stdout) throws MojoExecutionException, IOException {
+        CliCommandBuilder builder = createCommandBuilder(config, scriptFile);
+        return launchProcess(builder, config, stdout);
+    }
+}

--- a/plugin/src/main/java/org/wildfly/plugin/cli/ScriptWriter.java
+++ b/plugin/src/main/java/org/wildfly/plugin/cli/ScriptWriter.java
@@ -40,7 +40,7 @@ class ScriptWriter {
      *
      * @throws IOException if an error occurs creating the script file
      */
-    static Path create(final CommandConfiguration config) throws IOException {
+    static Path create(final BaseCommandConfiguration config) throws IOException {
         final Path tempScript = Files.createTempFile("cli-scrpts", ".cli");
         try (BufferedWriter writer = Files.newBufferedWriter(tempScript, StandardCharsets.UTF_8)) {
             if (config.isBatch()) {

--- a/plugin/src/main/java/org/wildfly/plugin/server/RunMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/server/RunMojo.java
@@ -275,7 +275,8 @@ public class RunMojo extends AbstractServerConnection {
                         .setJBossHome(commandBuilder.getWildFlyHome())
                         .setFork(true)
                         .setStdout("none")
-                        .setTimeout(timeout);
+                        .setTimeout(timeout)
+                        .build();
                 commandExecutor.execute(cmdConfig, mavenRepoManager);
                 // Create the deployment and deploy
                 final Deployment deployment = Deployment.of(deploymentContent)


### PR DESCRIPTION
* Introduce a BaseCommandConfiguration CLI configuration class and builder.
* Refactor CommandConfiguration to inherit from BaseCommandConfiguration and expose builder.
* Introduce an AbstractCommandExecutor.
* Refactor the CommandExecutor to inherit from the AbstractCommandExecutor
* Introduce an OfflineCommandExecutor to inherit from the AbstractCommandExecutor.
* OfflineCommandExecutor is injected into the package goal
* CommandExecutor is injected into other goals (unchanged).