### PR TITLE
Fix for WFWIP-439 and WFWIP-440, provisioning-dir can be set to absolute path, '.' and outside target dir

### DIFF
--- a/plugin/src/main/java/org/wildfly/plugin/provision/PackageServerMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/provision/PackageServerMojo.java
@@ -325,7 +325,7 @@ public class PackageServerMojo extends AbstractProvisionServerMojo {
         } else {
             filename = this.filename;
         }
-        Path deployment = targetDir.toPath().resolve(filename);
+        Path deployment = Paths.get(project.getBuild().getDirectory()).resolve(filename);
         if (Files.notExists(deployment)) {
             if (this.filename != null ) {
                 throw new MojoExecutionException("No deployment found wih name " + this.filename);


### PR DESCRIPTION
Issues:
https://issues.redhat.com/browse/WFWIP-439
https://issues.redhat.com/browse/WFWIP-440