### PR TITLE
Fix for WFMP-146, Add the ability to provide a name for layers based configuration

### DIFF
--- a/core/src/main/java/org/wildfly/plugin/core/GalleonUtils.java
+++ b/core/src/main/java/org/wildfly/plugin/core/GalleonUtils.java
@@ -35,7 +35,6 @@ import org.jboss.galleon.universe.maven.repo.MavenRepoManager;
 import org.jboss.galleon.xml.ProvisioningXmlParser;
 import static org.wildfly.plugin.core.Constants.FORK_EMBEDDED_PROCESS_OPTION;
 import static org.wildfly.plugin.core.Constants.STANDALONE;
-import static org.wildfly.plugin.core.Constants.STANDALONE_XML;
 
 /**
  * @author jdenise
@@ -111,6 +110,7 @@ public class GalleonUtils {
      * @param layers Layers to include.
      * @param excludedLayers Layers to exclude.
      * @param pluginOptions Galleon plugin options.
+     * @param layersConfigFileName The name of the configuration generated from layers
      * @return The provisioning config.
      * @throws ProvisioningException
      */
@@ -118,7 +118,7 @@ public class GalleonUtils {
             List<FeaturePack> featurePacks,
             List<String> layers,
             List<String> excludedLayers,
-            Map<String, String> pluginOptions) throws ProvisioningException, IllegalArgumentException {
+            Map<String, String> pluginOptions, String layersConfigFileName) throws ProvisioningException, IllegalArgumentException {
         final ProvisioningConfig.Builder state = ProvisioningConfig.builder();
         boolean hasLayers = !layers.isEmpty();
         boolean fpWithDefaults = true;
@@ -215,7 +215,7 @@ public class GalleonUtils {
 
         if (!layers.isEmpty()) {
             ConfigModel.Builder configBuilder = ConfigModel.
-                    builder(STANDALONE, STANDALONE_XML);
+                    builder(STANDALONE, layersConfigFileName);
             for (String layer : layers) {
                 configBuilder.includeLayer(layer);
             }

--- a/plugin/src/main/java/org/wildfly/plugin/common/PropertyNames.java
+++ b/plugin/src/main/java/org/wildfly/plugin/common/PropertyNames.java
@@ -107,6 +107,8 @@ public interface PropertyNames {
 
     String WILDFLY_AUTH_CLIENT_CONFIG = "wildfly.authConfig";
 
+    String WILDFLY_LAYERS_CONFIGURATION_FILE_NAME = "wildfly.provisioning.layers.configuration.file.name";
+
     String WILDFLY_PACKAGING_EXTRA_CONTENT_DIRS = "wildfly.packaging.extra.dirs";
 
     String WILDFLY_PROVISIONING_DIR = "wildfly.provisioning.dir";

--- a/plugin/src/main/java/org/wildfly/plugin/provision/AbstractProvisionServerMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/provision/AbstractProvisionServerMojo.java
@@ -51,6 +51,7 @@ import org.wildfly.plugin.common.PropertyNames;
 import org.wildfly.plugin.common.Utils;
 import org.wildfly.plugin.core.GalleonUtils;
 import static org.wildfly.plugin.core.Constants.PLUGIN_PROVISIONING_FILE;
+import static org.wildfly.plugin.core.Constants.STANDALONE_XML;
 import org.wildfly.plugin.core.MavenRepositoriesEnricher;
 
 
@@ -156,6 +157,13 @@ abstract class AbstractProvisionServerMojo extends AbstractMojo {
     @Parameter(alias = "provisioning-file", property = PropertyNames.WILDFLY_PROVISIONING_FILE, defaultValue = "${project.basedir}/galleon/provisioning.xml")
     private File provisioningFile;
 
+    /**
+     * The name of the configuration file generated from layers. Default value is {@code standalone.xml}.
+     * If no {@code layers} have been configured, setting this parameter is invalid.
+     */
+    @Parameter(alias = "layers-configuration-file-name", property = PropertyNames.WILDFLY_LAYERS_CONFIGURATION_FILE_NAME, defaultValue = STANDALONE_XML)
+    String layersConfigurationFileName;
+
     private Path wildflyDir;
 
     protected MavenRepoManager artifactResolver;
@@ -224,7 +232,10 @@ abstract class AbstractProvisionServerMojo extends AbstractMojo {
                 if (provisioningFileExists) {
                     getLog().warn("Galleon provisioning file " + provisioningFile + " is ignored, plugin configuration is used.");
                 }
-                config = GalleonUtils.buildConfig(pm, featurePacks, layers, excludedLayers, galleonOptions);
+                if (layers.isEmpty() && !STANDALONE_XML.equals(layersConfigurationFileName)) {
+                    throw new MojoExecutionException("layers-configuration-file-name has been set although no layers are defined.");
+                }
+                config = GalleonUtils.buildConfig(pm, featurePacks, layers, excludedLayers, galleonOptions, layersConfigurationFileName);
             }
             getLog().info("Provisioning server in " + home);
             pm.provision(config);

--- a/plugin/src/main/java/org/wildfly/plugin/provision/PackageServerMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/provision/PackageServerMojo.java
@@ -107,7 +107,8 @@ public class PackageServerMojo extends AbstractProvisionServerMojo {
 
     /**
      * The name of the server configuration to use when deploying the
-     * deployment. Defaults to 'standalone.xml'.
+     * deployment. Defaults to 'standalone.xml'. If {@code layers-configuration-file-name} has been set,
+     * this property is ignored and the deployment is deployed inside the configuration referenced from {@code layers-configuration-file-name}.
      */
     @Parameter(property = PropertyNames.SERVER_CONFIG, alias = "server-config", defaultValue = STANDALONE_XML)
     private String serverConfig;
@@ -269,7 +270,11 @@ public class PackageServerMojo extends AbstractProvisionServerMojo {
             return commands;
         }
         List<String> offlineCommands = new ArrayList<>();
-        offlineCommands.add("embed-server --server-config=" + serverConfig);
+        String serverConfigName = serverConfig;
+        if (!layersConfigurationFileName.equals(STANDALONE_XML)) {
+            serverConfigName = layersConfigurationFileName;
+        }
+        offlineCommands.add("embed-server --server-config=" + serverConfigName);
         offlineCommands.addAll(commands);
         offlineCommands.add("stop-embedded-server");
          return offlineCommands;


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFMP-146
Introduce new configuration item to provide a name for the generated config (default being standalone.xml).