### PR TITLE
Fix for WFWIP-460, When extra-content-dir is a regular file, build pr…

### DIFF
--- a/plugin/src/main/java/org/wildfly/plugin/provision/PackageServerMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/provision/PackageServerMojo.java
@@ -310,6 +310,9 @@ public class PackageServerMojo extends AbstractProvisionServerMojo {
             if (Files.notExists(extraContent)) {
                 throw new MojoExecutionException("Extra content dir " + extraContent + " doesn't exist");
             }
+            if (!Files.isDirectory(extraContent)) {
+                throw new MojoExecutionException("Extra content dir " + extraContent + " is not a directory");
+            }
             // Check for the presence of a standalone.xml file
             warnExtraConfig(extraContent);
             IoUtils.copy(extraContent, target);


### PR DESCRIPTION
…ocess fails without explanation

https://issues.redhat.com/browse/WFMP-162