### PR TITLE
[WFMP-165] Split module paths before calling addModulePaths()

### DIFF
--- a/plugin/src/main/java/org/wildfly/plugin/cli/ExecuteCommandsMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/cli/ExecuteCommandsMojo.java
@@ -325,7 +325,8 @@ public class ExecuteCommandsMojo extends AbstractServerConnection {
             if (systemProperties != null) {
                 systemProperties.forEach((key, value) -> builder.addJavaOption(String.format("-D%s=%s", key, value)));
                 if (systemProperties.containsKey("module.path")) {
-                    builder.setModuleDirs(systemProperties.get("module.path"));
+                    String[] modulePaths = systemProperties.get("module.path").split(File.pathSeparator);
+                    builder.setModuleDirs(modulePaths);
                 }
             }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFMP-165