### PR TITLE
Fix for WFMP-170, Must upgrade to Galleon 5.0.5.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
         <maven.compiler.source>11</maven.compiler.source>
 
         <!-- galleon properties -->
-        <version.org.jboss.galleon>5.0.1.Final</version.org.jboss.galleon>
+        <version.org.jboss.galleon>5.0.5.Final</version.org.jboss.galleon>
         <plugin.fork.embedded>true</plugin.fork.embedded>
         <!-- used by tests -->
         <version.org.jboss.logging.slf4j-jboss-logging>1.2.1.Final</version.org.jboss.logging.slf4j-jboss-logging>


### PR DESCRIPTION
That will be required as soon as https://github.com/wildfly/wildfly/pull/15827 is in.