### PR TITLE
[WFMP-175] Add property to skip the deployment in the package goal.

### DIFF
--- a/plugin/src/main/java/org/wildfly/plugin/common/PropertyNames.java
+++ b/plugin/src/main/java/org/wildfly/plugin/common/PropertyNames.java
@@ -97,6 +97,8 @@ public interface PropertyNames {
 
     String SKIP_PACKAGE = "wildfly.package.skip";
 
+    String SKIP_PACKAGE_DEPLOYMENT = "wildfly.package.deployment.skip";
+
     String STARTUP_TIMEOUT = "wildfly.startupTimeout";
 
     String STDOUT = "wildfly.stdout";

--- a/plugin/src/main/java/org/wildfly/plugin/provision/PackageServerMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/provision/PackageServerMojo.java
@@ -160,6 +160,12 @@ public class PackageServerMojo extends AbstractProvisionServerMojo {
     @Parameter(defaultValue = "false", property = PropertyNames.SKIP_PACKAGE)
     private boolean skip;
 
+    /**
+     * Skip deploying the deployment after the server is provisioned ({@code false} by default).
+     */
+    @Parameter(defaultValue = "false", property = PropertyNames.SKIP_PACKAGE)
+    protected boolean skipDeployment;
+
     @Inject
     private OfflineCommandExecutor commandExecutor;
 
@@ -198,19 +204,22 @@ public class PackageServerMojo extends AbstractProvisionServerMojo {
             throw new MojoExecutionException(ex.getLocalizedMessage(), ex);
         }
 
-        final Path deploymentContent = getDeploymentContent();
-        if (Files.exists(deploymentContent)) {
-            getLog().info("Deploying " + deploymentContent);
-            List<String> deploymentCommands = getDeploymentCommands(deploymentContent);
-            final BaseCommandConfiguration cmdConfigDeployment = new BaseCommandConfiguration.Builder()
-                    .addCommands(deploymentCommands)
-                    .setJBossHome(jbossHome)
-                    .addCLIArguments(CLI_ECHO_COMMAND_ARG)
-                    .setAppend(true)
-                    .setStdout(stdout)
-                    .build();
-            commandExecutor.execute(cmdConfigDeployment, artifactResolver);
+        if (!skipDeployment) {
+            final Path deploymentContent = getDeploymentContent();
+            if (Files.exists(deploymentContent)) {
+                getLog().info("Deploying " + deploymentContent);
+                List<String> deploymentCommands = getDeploymentCommands(deploymentContent);
+                final BaseCommandConfiguration cmdConfigDeployment = new BaseCommandConfiguration.Builder()
+                        .addCommands(deploymentCommands)
+                        .setJBossHome(jbossHome)
+                        .addCLIArguments(CLI_ECHO_COMMAND_ARG)
+                        .setAppend(true)
+                        .setStdout(stdout)
+                        .build();
+                commandExecutor.execute(cmdConfigDeployment, artifactResolver);
+            }
         }
+
         // CLI execution
          try {
              if (!packagingScripts.isEmpty()) {


### PR DESCRIPTION
If wildfly.package.deployment.skip is true, the user deployment will not be deployed in the provisioned server.

JIRA: https://issues.redhat.com/browse/WFMP-175

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>