### PR TITLE
Push image from project build directory path instead of hard target path

### DIFF
--- a/plugin/src/main/java/org/wildfly/plugin/provision/ApplicationImageMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/provision/ApplicationImageMojo.java
@@ -192,7 +192,7 @@ public class ApplicationImageMojo extends PackageServerMojo {
         String[] dockerArgs = new String[] {"push", image};
 
         getLog().info(format("Executing the following command to push application image: '%s %s'", this.image.dockerBinary, join(" ", dockerArgs)));
-        return ExecUtil.exec(getLog(), Paths.get("target").toFile(), this.image.dockerBinary, dockerArgs);
+        return ExecUtil.exec(getLog(), Paths.get(project.getBuild().getDirectory()).toFile(), this.image.dockerBinary, dockerArgs);
     }
 
     private void generateDockerfile(String runtimeImage, Path targetDir, String wildflyDirectory) throws IOException {


### PR DESCRIPTION
Why the pull request?

We're currently using the wildfly plugin from a child pom. When we call the child pom from the parent pom, the plugin wants to push the image from the directory <parent_pom>/target, which does not exist. Only the directory <child_pom>/target exists. Generating and building the docker file all happens from the project build directory as well, so hopefully this makes sense.