### PR TITLE
Wrong system property name to skip deployment

### DIFF
--- a/plugin/src/main/java/org/wildfly/plugin/provision/PackageServerMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/provision/PackageServerMojo.java
@@ -163,7 +163,7 @@ public class PackageServerMojo extends AbstractProvisionServerMojo {
     /**
      * Skip deploying the deployment after the server is provisioned ({@code false} by default).
      */
-    @Parameter(defaultValue = "false", property = PropertyNames.SKIP_PACKAGE)
+    @Parameter(defaultValue = "false", property = PropertyNames.SKIP_PACKAGE_DEPLOYMENT)
     protected boolean skipDeployment;
 
     @Inject


### PR DESCRIPTION
Skiping the deployment using a system property won't work since it uses the skip.package name