### PR TITLE
[WFMP-182] Update WildFly runtime image names

### DIFF
--- a/plugin/src/main/java/org/wildfly/plugin/provision/ApplicationImageInfo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/provision/ApplicationImageInfo.java
@@ -38,10 +38,11 @@ public class ApplicationImageInfo {
     protected boolean push = false;
 
     /**
-     * Determine which WildFly Runtime image to use so that the application runs with the specified JDK.
-     * The default is "11". Accepted values are "11", "17".
+     * Determine which WildFly runtime image to use so that the application runs with the specified JDK.
+     * If the value is not set, the `latest` tag of the WildFly runtime image is used.
+     * Accepted values are "11", "17".
      */
-    private String jdkVersion = "11";
+    private String jdkVersion;
 
     /**
      * The group part of the name of the application image.
@@ -91,11 +92,17 @@ public class ApplicationImageInfo {
     }
 
     String getWildFlyRuntimeImage() {
-        switch (jdkVersion) {
-            case "17":
-                return "quay.io/wildfly/wildfly-runtime-jdk17:latest";
-            default:
-                return "quay.io/wildfly/wildfly-runtime-jdk11:latest";
+        String runtimeImageName = "quay.io/wildfly/wildfly-runtime:";
+        String runtimeImageTag = "";
+        if (jdkVersion == null) {
+            runtimeImageTag = "latest";
+        } else {
+            switch (jdkVersion) {
+                case "17":
+                case "11":
+                    runtimeImageTag = "latest-jdk" + jdkVersion;
+            }
         }
+        return runtimeImageName + runtimeImageTag;
     }
 }

--- a/plugin/src/main/java/org/wildfly/plugin/provision/ApplicationImageMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/provision/ApplicationImageMojo.java
@@ -75,7 +75,7 @@ public class ApplicationImageMojo extends PackageServerMojo {
      *   &lt;!-- (optional) The binary used to perform image commands (build, login, push) (default is "docker") --&gt;
      *   &lt;docker-binary&gt;docker&lt;/docker-binary&gt;
      *
-     *   &lt;!-- (optional) the JDK version used by the application. Default is "11", Allowed values are "11" and "17 --&gt;
+     *   &lt;!-- (optional) the JDK version used by the application. Allowed values are "11" and "17". If unspecified, the "latest" tag is used to determine the JDK version used by WildFly runtime image --&gt;
      *   &lt;jdk-version&gt;11&lt;/jdk-version&gt;
      *
      *   &lt;!-- (optional) The group part of the name of the application image --&gt;


### PR DESCRIPTION
Use the new naming convention for the WildFly runtime image. They all have the same name, `quay.io/wildfly/wildfly-runtime` and uses tags to specify the JDK version.

By default, `jdkVersion` is no longer set so that the WildFLy runtime image will use its latest tag by default. This tag corresponds to the most recent LTS JDK version provided by WildFly (11 at the moment, eventually 17, etc).

User can stay on a specify JDK version by setting <jdk-version> to 11 or 17.

JIRA: https://issues.redhat.com/browse/WFMP-182

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>