### PR TITLE
[WFMP-186] Optimize the application image generated by the image goal

### DIFF
--- a/plugin/src/main/java/org/wildfly/plugin/provision/PackageServerMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/provision/PackageServerMojo.java
@@ -213,13 +213,7 @@ public class PackageServerMojo extends AbstractProvisionServerMojo {
             if (Files.exists(deploymentContent)) {
                 Path standaloneDeploymentDir = Paths.get(project.getBuild().getDirectory(), provisioningDir, "standalone", "deployments").normalize();
                 try {
-                    String targetName;
-                    if (runtimeName != null) {
-                        targetName = runtimeName;
-                    } else {
-                        targetName = name != null ? name : deploymentContent.getFileName().toString();
-                    }
-                    Path deploymentTarget = standaloneDeploymentDir.resolve(targetName);
+                    Path deploymentTarget = standaloneDeploymentDir.resolve(getDeploymentTargetName());
                     getLog().info("Copy deployment " + deploymentContent + " to " + deploymentTarget);
                     Files.copy(deploymentContent, deploymentTarget, StandardCopyOption.REPLACE_EXISTING);
                 } catch (IOException e) {
@@ -259,6 +253,20 @@ public class PackageServerMojo extends AbstractProvisionServerMojo {
         } catch (IOException ex) {
             throw new MojoExecutionException(ex.getLocalizedMessage(), ex);
         }
+    }
+
+    /** Return the file name of the deployment to put in the server deployment directory
+     *
+     * @throws MojoExecutionException
+     */
+    protected String getDeploymentTargetName() throws MojoExecutionException {
+        String targetName;
+        if (runtimeName != null) {
+            targetName = runtimeName;
+        } else {
+            targetName = name != null ? name : getDeploymentContent().getFileName().toString();
+        }
+        return targetName;
     }
 
     private List<File> resolveFiles(List<File> files) {
@@ -335,7 +343,7 @@ public class PackageServerMojo extends AbstractProvisionServerMojo {
         }
     }
 
-    private Path getDeploymentContent() throws MojoExecutionException {
+    protected Path getDeploymentContent() throws MojoExecutionException {
         final PackageType packageType = PackageType.resolve(project);
         final String filename;
         if (this.filename == null) {

--- a/tests/standalone-tests/src/test/resources/test-project/image-pom.xml
+++ b/tests/standalone-tests/src/test/resources/test-project/image-pom.xml
@@ -39,6 +39,7 @@
                         <layer>jaxrs-server</layer>
                     </layers>
                     <provisioning-dir>image-server</provisioning-dir>
+                    <filename>test.war</filename>
                     <image>
                         <group>wildfly-maven-plugin</group>
                     </image>


### PR DESCRIPTION
In the image goal, skip the deployment when packaging WildFly

In the generated Dockerfile, use 2 different COPY commands:

* COPY the server bits. This Docker layer can be cached (as long as the server provisioning does not change)
* COPY the deployment in the standalone/deployment directory. This Docker layer is small (the size of the deployment) and will be changed every time

With that optimization, repeatedly pushing the application image will mean to push the deployment Docker layer only.

This optimization saves time, bandwith and storage on the container registry.

JIRA: https://issues.redhat.com/browse/WFMP-186