### PR TITLE
[WFMP-193] Add the dev goal to the index.

### DIFF
--- a/plugin/src/site/markdown/index.md.vm
+++ b/plugin/src/site/markdown/index.md.vm
@@ -29,6 +29,8 @@
 
   * [${pluginPrefix}:undeploy](./undeploy-mojo.html) undeploys the application.
 
+  * [${pluginPrefix}:dev](./dev-mojo.html) runs the application server, if applicable, and deploys your application watching for source changes.
+
   * [${pluginPrefix}:run](./run-mojo.html) runs the application server and deploys your application.
 
   * [${pluginPrefix}:start](./start-mojo.html) starts the application server and leaves the process running. In most cases


### PR DESCRIPTION
https://issues.redhat.com/browse/WFMP-193

I was not able to update the "provisioningDir configuration parameter marked as since 3.0" as it would require either removing the `@since` or overriding the property which would add complications. It's doesn't feel like too big of a deal to just deal with it.