### PR TITLE
Fix for WFMP-197, Move PluginProgressTracker class to core module

### DIFF
--- a/core/src/main/java/org/wildfly/plugin/core/PluginProgressTracker.java
+++ b/core/src/main/java/org/wildfly/plugin/core/PluginProgressTracker.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.wildfly.plugin.provision;
+package org.wildfly.plugin.core;
 
 import org.apache.maven.plugin.logging.Log;
 import org.jboss.galleon.ProvisioningManager;
@@ -26,7 +26,7 @@ import org.jboss.galleon.progresstracking.ProgressTracker;
  *
  * @author jdenise@redhat.com
  */
-class PluginProgressTracker<T> implements ProgressCallback<T> {
+public class PluginProgressTracker<T> implements ProgressCallback<T> {
 
     private static final String DELAYED_EXECUTION_MSG = "Delayed generation, waiting...";
     private final Log log;

--- a/plugin/src/main/java/org/wildfly/plugin/provision/AbstractProvisionServerMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/provision/AbstractProvisionServerMojo.java
@@ -55,7 +55,7 @@ import static org.wildfly.plugin.core.Constants.PLUGIN_PROVISIONING_FILE;
 import static org.wildfly.plugin.core.Constants.STANDALONE_XML;
 import org.wildfly.plugin.core.FeaturePack;
 import org.wildfly.plugin.core.MavenRepositoriesEnricher;
-
+import org.wildfly.plugin.core.PluginProgressTracker;
 
 /**
  * Provision a server


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFMP-197