### PR TITLE
Use prospero BOM to manage shared dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,15 +89,12 @@
 
     <properties>
         <!-- WildFly/JBoss dependencies -->
-        <version.org.jboss.logging.jboss-logging>3.5.0.Final</version.org.jboss.logging.jboss-logging>
-        <version.org.jboss.logmanager>2.1.19.Final</version.org.jboss.logmanager>
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.common.wildfly-common>1.6.0.Final</version.org.wildfly.common.wildfly-common>
         <!-- This version property is also retrieved by plugin at runtime to resolve CLI artifact -->
         <version.org.wildfly.core>20.0.1.Final</version.org.wildfly.core>
         <version.org.wildfly>27.0.1.Final</version.org.wildfly>
-        <version.org.wildfly.channel>1.0.1.Final</version.org.wildfly.channel>
-        <version.org.wildfly.prospero>1.0.0.Final</version.org.wildfly.prospero>
+        <version.org.wildfly.prospero>1.0.2.Final-SNAPSHOT</version.org.wildfly.prospero>
         <!-- maven dependencies -->
         <version.javax.inject.javax.inject>1</version.javax.inject.javax.inject>
         <version.org.apache.maven.maven-core>3.6.2</version.org.apache.maven.maven-core>
@@ -105,7 +102,6 @@
         </version.org.apache.maven.plugin-testing.maven-plugin-testing-harness>
         <version.org.apache.maven.plugin-tools>3.7.0</version.org.apache.maven.plugin-tools>
         <version.org.apache.maven.shared>0.9.1</version.org.apache.maven.shared>
-        <version.org.apache.maven.resolver>1.9.6</version.org.apache.maven.resolver>
         <version.org.eclipse.sisu>0.3.5</version.org.eclipse.sisu>
         <version.org.twdata.maven>2.3.1</version.org.twdata.maven>
 
@@ -244,6 +240,13 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>org.wildfly.prospero</groupId>
+                <artifactId>prospero</artifactId>
+                <version>${version.org.wildfly.prospero}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
                 <groupId>javax.inject</groupId>
                 <artifactId>javax.inject</artifactId>
                 <version>${version.javax.inject.javax.inject}</version>
@@ -277,41 +280,6 @@
                 <version>${version.org.apache.maven.plugin-tools}</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.maven.resolver</groupId>
-                <artifactId>maven-resolver-api</artifactId>
-                <version>${version.org.apache.maven.resolver}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.maven.resolver</groupId>
-                <artifactId>maven-resolver-spi</artifactId>
-                <version>${version.org.apache.maven.resolver}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.maven.resolver</groupId>
-                <artifactId>maven-resolver-impl</artifactId>
-                <version>${version.org.apache.maven.resolver}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.maven.resolver</groupId>
-                <artifactId>maven-resolver-connector-basic</artifactId>
-                <version>${version.org.apache.maven.resolver}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.maven.resolver</groupId>
-                <artifactId>maven-resolver-transport-http</artifactId>
-                <version>${version.org.apache.maven.resolver}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.maven.resolver</groupId>
-                <artifactId>maven-resolver-util</artifactId>
-                <version>${version.org.apache.maven.resolver}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.maven.resolver</groupId>
-                <artifactId>maven-resolver-named-locks</artifactId>
-                <version>${version.org.apache.maven.resolver}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.jboss.galleon</groupId>
                 <artifactId>galleon-maven-plugin</artifactId>
                 <version>${version.org.jboss.galleon}</version>
@@ -321,11 +289,6 @@
                         <artifactId>*</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.galleon</groupId>
-                <artifactId>galleon-core</artifactId>
-                <version>${version.org.jboss.galleon}</version>
             </dependency>
             <dependency>
                 <groupId>org.jboss.galleon</groupId>
@@ -349,11 +312,6 @@
                         <artifactId>aether-util</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.logging</groupId>
-                <artifactId>jboss-logging</artifactId>
-                <version>${version.org.jboss.logging.jboss-logging}</version>
             </dependency>
             <dependency>
                 <groupId>org.wildfly.common</groupId>
@@ -380,16 +338,6 @@
                 <groupId>org.wildfly.plugins</groupId>
                 <artifactId>wildfly-plugin-core</artifactId>
                 <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.wildfly.channel</groupId>
-                <artifactId>channel-core</artifactId>
-                <version>${version.org.wildfly.channel}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.wildfly.channel</groupId>
-                <artifactId>maven-resolver</artifactId>
-                <version>${version.org.wildfly.channel}</version>
             </dependency>
             <dependency>
                 <groupId>org.wildfly.checkstyle</groupId>
@@ -447,11 +395,6 @@
                 <groupId>org.apache.maven.plugin-testing</groupId>
                 <artifactId>maven-plugin-testing-harness</artifactId>
                 <version>${version.org.apache.maven.plugin-testing.maven-plugin-testing-harness}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.logmanager</groupId>
-                <artifactId>jboss-logmanager</artifactId>
-                <version>${version.org.jboss.logmanager}</version>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>


### PR DESCRIPTION
Uses prospero parent as BOM to allign shared dependency versions

Requires https://github.com/wildfly-extras/prospero/pull/401 

cc @jfdenise
