### PR TITLE
[WFMP-227] Do not append the build directory to defined provisioning …

### DIFF
--- a/plugin/src/main/java/org/wildfly/plugin/provision/PackageServerMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/provision/PackageServerMojo.java
@@ -215,8 +215,10 @@ public class PackageServerMojo extends AbstractProvisionServerMojo {
         if (!skipDeployment) {
             final Path deploymentContent = getDeploymentContent();
             if (Files.exists(deploymentContent)) {
-                Path standaloneDeploymentDir = Paths
-                        .get(project.getBuild().getDirectory(), provisioningDir, "standalone", "deployments").normalize();
+                Path standaloneDeploymentDir = Path.of(provisioningDir, "standalone", "deployments");
+                if (!standaloneDeploymentDir.isAbsolute()) {
+                    standaloneDeploymentDir = Path.of(project.getBuild().getDirectory()).resolve(standaloneDeploymentDir);
+                }
                 try {
                     Path deploymentTarget = standaloneDeploymentDir.resolve(getDeploymentTargetName());
                     getLog().info("Copy deployment " + deploymentContent + " to " + deploymentTarget);


### PR DESCRIPTION
…directories if the directory is absolute in the package goal.

https://issues.redhat.com/browse/WFMP-227

Upstream: #420 