### PR TITLE
[WFMP-228] Handle the server state after CLI commands are executed. F…

### DIFF
--- a/plugin/src/main/java/org/wildfly/plugin/dev/DevMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/dev/DevMojo.java
@@ -430,7 +430,7 @@ public class DevMojo extends AbstractServerStartMojo {
                             .addCommands(commands)
                             .addScripts(scripts)
                             .setStdout("none")
-                            .setAutoReload(true)
+                            .setAutoReload(false)
                             .setTimeout(timeout);
                     if (context == null) {
                         builder.setOffline(false)
@@ -440,6 +440,11 @@ public class DevMojo extends AbstractServerStartMojo {
                                 .setFork(true);
                     }
                     commandExecutor.execute(builder.build(), mavenRepoManager);
+                    // Check the server state. We may need to restart the process, assuming we control the context
+                    if (context != null) {
+                        context = actOnServerState(client, context);
+                    }
+
                     final DeploymentManager deploymentManager = DeploymentManager.Factory.create(client);
                     final Deployment deployment = getDeploymentContent();
                     try {

--- a/plugin/src/main/java/org/wildfly/plugin/server/RunMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/server/RunMojo.java
@@ -132,12 +132,14 @@ public class RunMojo extends AbstractServerStartMojo {
                         .addCommands(commands)
                         .addScripts(scripts)
                         .setJBossHome(context.jbossHome())
-                        .setAutoReload(true)
+                        .setAutoReload(false)
                         .setFork(true)
                         .setStdout("none")
                         .setTimeout(timeout)
                         .build();
                 commandExecutor.execute(cmdConfig, mavenRepoManager);
+
+                process = actOnServerState(client, context).process();
                 // Create the deployment and deploy
                 final Deployment deployment = Deployment.of(deploymentContent)
                         .setName(name)


### PR DESCRIPTION
…or the execute-command goal a message is logged if the state is not "running". For the dev goal and run goal, decisions are made based on the server state.

https://issues.redhat.com/browse/WFMP-228

Upstream #422 