### PR TITLE
Fix for WFMP-236, The generated configuration name is not used when WildFly Glow is enabled

### DIFF
--- a/plugin/src/main/java/org/wildfly/plugin/common/Utils.java
+++ b/plugin/src/main/java/org/wildfly/plugin/common/Utils.java
@@ -134,7 +134,8 @@ public class Utils {
                 p.storeProvisioningConfig(in, inProvisioningFile);
             }
         }
-        Arguments arguments = discoverProvisioningInfo.toArguments(deploymentContent, inProvisioningFile);
+        Arguments arguments = discoverProvisioningInfo.toArguments(deploymentContent, inProvisioningFile,
+                layersConfigurationFileName);
         log.info("Glow is scanning... ");
         ScanResults results;
         GlowMavenMessageWriter writer = new GlowMavenMessageWriter(log);

--- a/plugin/src/main/java/org/wildfly/plugin/provision/GlowConfig.java
+++ b/plugin/src/main/java/org/wildfly/plugin/provision/GlowConfig.java
@@ -32,7 +32,7 @@ public class GlowConfig {
     public GlowConfig() {
     }
 
-    public Arguments toArguments(Path deployment, Path inProvisioning) {
+    public Arguments toArguments(Path deployment, Path inProvisioning, String layersConfigurationFileName) {
         final Set<String> profiles = profile != null ? Set.of(profile) : Set.of();
         List<Path> lst = List.of(deployment);
         Builder builder = Arguments.scanBuilder().setExecutionContext(context).setExecutionProfiles(profiles)
@@ -43,6 +43,9 @@ public class GlowConfig {
                 .setOutput(OutputFormat.PROVISIONING_XML);
         if (inProvisioning != null) {
             builder.setProvisoningXML(inProvisioning);
+        }
+        if (layersConfigurationFileName != null) {
+            builder.setConfigName(layersConfigurationFileName);
         }
         return builder.build();
     }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFMP-236
