### PR TITLE
Allow the "file:relative/path" URL notation for manifest coordinate

### DIFF
--- a/plugin/src/main/java/org/wildfly/plugin/provision/ChannelConfiguration.java
+++ b/plugin/src/main/java/org/wildfly/plugin/provision/ChannelConfiguration.java
@@ -23,7 +23,7 @@ import org.wildfly.channel.Repository;
  * @author jdenise
  */
 public class ChannelConfiguration {
-    private static final Pattern FILE_MATCHER = Pattern.compile("^(file|http|https)://.*");
+    private static final Pattern FILE_MATCHER = Pattern.compile("^(file:|http://|https://).*");
 
     private ChannelManifestCoordinate manifest;
 

--- a/plugin/src/test/java/org/wildfly/plugin/provision/ChannelConfigurationTestCase.java
+++ b/plugin/src/test/java/org/wildfly/plugin/provision/ChannelConfigurationTestCase.java
@@ -9,7 +9,9 @@ import java.net.URL;
 import java.util.Collections;
 
 import org.apache.maven.plugin.MojoExecutionException;
+import org.junit.Assert;
 import org.junit.Test;
+import org.wildfly.channel.Channel;
 import org.wildfly.channel.ChannelManifestCoordinate;
 import org.wildfly.channel.ChannelMetadataCoordinate;
 
@@ -178,6 +180,33 @@ public class ChannelConfigurationTestCase {
             url.set(coordinate, new URL("http://org.example"));
             configuration.setManifest(coordinate);
             configuration.toChannel(Collections.emptyList());
+        }
+    }
+
+    @Test
+    public void testFileUrl() throws Exception {
+        {
+            // Make sure that the notation "file:relative/path" is handled like a file URL, rather than a Maven G:A.
+
+            String url = "file:path/to/manifest.yaml";
+            ChannelConfiguration configuration = new ChannelConfiguration();
+            configuration.set(url);
+            Channel channel = configuration.toChannel(Collections.emptyList());
+
+            Assert.assertNotNull(channel.getManifestCoordinate().getUrl());
+            Assert.assertEquals(url, channel.getManifestCoordinate().getUrl().toExternalForm());
+        }
+
+        {
+            // The notation "file://relative/path" should still be handled like a file URL too.
+
+            String url = "file://path/to/manifest.yaml";
+            ChannelConfiguration configuration = new ChannelConfiguration();
+            configuration.set(url);
+            Channel channel = configuration.toChannel(Collections.emptyList());
+
+            Assert.assertNotNull(channel.getManifestCoordinate().getUrl());
+            Assert.assertEquals(url, channel.getManifestCoordinate().getUrl().toExternalForm());
         }
     }
 }


### PR DESCRIPTION
I find it impossible to reference a local manifest file.

When I use "file://path/to/manifest.yaml", I get:

```
Caused by: java.net.UnknownHostException: wildfly-ee-galleon-pack-32.0.0.Beta1-SNAPSHOT-manifest.yaml
    at sun.nio.ch.NioSocketImpl.connect (NioSocketImpl.java:572)
    at java.net.Socket.connect (Socket.java:633)
    at sun.net.ftp.impl.FtpClient.doConnect (FtpClient.java:1045)
    at sun.net.ftp.impl.FtpClient.tryConnect (FtpClient.java:1010)
    at sun.net.ftp.impl.FtpClient.connect (FtpClient.java:1102)
    at sun.net.ftp.impl.FtpClient.connect (FtpClient.java:1088)
    at sun.net.www.protocol.ftp.FtpURLConnection.connect (FtpURLConnection.java:320)
    at sun.net.www.protocol.ftp.FtpURLConnection.getInputStream (FtpURLConnection.java:426)
    at java.net.URL.openStream (URL.java:1161)
    at com.fasterxml.jackson.core.TokenStreamFactory._optimizedStreamFromURL (TokenStreamFactory.java:302)
    at com.fasterxml.jackson.dataformat.yaml.YAMLFactory.createParser (YAMLFactory.java:400)
    at com.fasterxml.jackson.dataformat.yaml.YAMLFactory.createParser (YAMLFactory.java:15)
    at com.fasterxml.jackson.databind.ObjectMapper.readTree (ObjectMapper.java:3329)
    at org.wildfly.channel.ChannelManifestMapper.validate (ChannelManifestMapper.java:131)
    at org.wildfly.channel.ChannelManifestMapper.from (ChannelManifestMapper.java:98)
```

When I use "file:path/to/manifest.yaml", the channel plugin takes it as a Maven G:A, not a URL.

This PR makes the plugin to recognize the "file:path/to/manifest.yaml" notation as a URL, which then allows the plugin to reference a local manifest file.

Cc @jfdenise @jamezp 