### PR TITLE
[WFMP-259] Add a dependency for the plexus-utils used by the execute-…

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -153,6 +153,10 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-utils</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-controller-client</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,7 @@
         <version.org.apache.maven.plugin-tools>3.7.0</version.org.apache.maven.plugin-tools>
         <version.org.apache.maven.shared>0.10.1</version.org.apache.maven.shared>
         <version.org.apache.maven.resolver>1.9.18</version.org.apache.maven.resolver>
+        <version.org.codehaus.plexus>3.5.1</version.org.codehaus.plexus>
         <!-- maven dependencies only required by tests -->
         <version.org.apache.maven.wagon>3.5.3</version.org.apache.maven.wagon>
 
@@ -304,6 +305,12 @@
                 <groupId>org.apache.maven.resolver</groupId>
                 <artifactId>maven-resolver-util</artifactId>
                 <version>${version.org.apache.maven.resolver}</version>
+            </dependency>
+            <!-- Required for the dev goal and the maven-execute dependency -->
+            <dependency>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-utils</artifactId>
+                <version>${version.org.codehaus.plexus}</version>
             </dependency>
             <dependency>
                 <groupId>org.jboss.galleon</groupId>


### PR DESCRIPTION
…mojo dependency. Previously this was a transitive dependency from maven-core which is now marked as provided.

https://issues.redhat.com/browse/WFMP-259