### PR TITLE
[WFMP-261] Deprecate the ApplicationImageInfo in favor of using param…

### DIFF
--- a/plugin/src/main/java/org/wildfly/plugin/provision/ApplicationImageInfo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/provision/ApplicationImageInfo.java
@@ -8,6 +8,7 @@ package org.wildfly.plugin.provision;
  * This class holds all configuration to build and push application image
  * from the {@code image} goal.
  */
+@Deprecated(forRemoval = true)
 public class ApplicationImageInfo {
 
     /**
@@ -25,22 +26,22 @@ public class ApplicationImageInfo {
      * If the value is not set, the `latest` tag of the WildFly runtime image is used.
      * Accepted values are "11", "17".
      */
-    private String jdkVersion;
+    protected String jdkVersion;
 
     /**
      * The group part of the name of the application image.
      */
-    private String group;
+    protected String group;
 
     /**
      * The name part of the application image. If not set, the value of the artifactId (in lower case) is used.
      */
-    private String name;
+    protected String name;
 
     /**
      * The tag part of the application image (default is @{code latest}.
      */
-    private String tag = "latest";
+    protected String tag = "latest";
 
     /**
      * The container registry.
@@ -66,7 +67,7 @@ public class ApplicationImageInfo {
      * {@code podman} is attempted. If neither is available {@code null} will be set as the default and an error will
      * occur if attempting to build or push an image.
      */
-    private String dockerBinary;
+    protected String dockerBinary;
 
     String getApplicationImageName(String artifactId) {
         String registry = this.registry != null ? this.registry + "/" : "";
@@ -83,11 +84,7 @@ public class ApplicationImageInfo {
         if (jdkVersion == null) {
             runtimeImageTag = "latest";
         } else {
-            switch (jdkVersion) {
-                case "17":
-                case "11":
-                    runtimeImageTag = "latest-jdk" + jdkVersion;
-            }
+            runtimeImageTag = "latest-jdk" + jdkVersion;
         }
         return runtimeImageName + runtimeImageTag;
     }

--- a/plugin/src/site/markdown/image-example.md.vm
+++ b/plugin/src/site/markdown/image-example.md.vm
@@ -4,12 +4,12 @@ The `image` goal allows you to build an application image that contains a server
 This application image contains your application ready to run on the cloud in a containerized platform such as Kubernetes.
 
 The operations related to the image are executing using a Docker binary. This can be explicitly set with the
-`<image><docker-binary>` element. It can also be overridden with the `wildfly.image.binary` property. If no binary is
+`<docker-binary>` element. It can also be overridden with the `wildfly.image.binary` property. If no binary is
 defined in the configuration, an attempt will be made to determine a default binary. First `docker` is attempted to be
 resolved. If it cannot be resolved, then `podman` is attempted. If neither can be resolved an error will occur.
 
 By default, the `image` goal will only build the application image.
-To push it to a container registry, you must configure the `<image><push>` element with to `true`.
+To push it to a container registry, you must configure the `<push>` element with to `true`.
 
 #[[##]]# Build an application image
 
@@ -90,13 +90,10 @@ The example below shows how to configure the `image` goal to push the applicaiti
                     <layers>
                         <layer>jaxrs-server</layer>
                     </layers>
-                    <image>
-                        <push>true</push>
-                        <registry>quay.io</registry>
-                        <group>${user.name}</group>
-                        <user>${user.name}</user>
-                        <password>${my.secret.password}</password>
-                    </image>
+                    <push>true</push>
+                    <registry>quay.io</registry>
+                    <group>${user.name}</group>
+                    <registryId>quay-io</registryId>
                 </configuration>
                 <executions>
                     <execution>
@@ -116,9 +113,10 @@ The example below shows how to configure the `image` goal to push the applicaiti
 
 When `mvn package` is executed, the `image` goal will build the image with the name `quay.io/jdoe/my-app` (`jdoe` being the name
 of the user running the Maven commands).
-Before the image is pushed, it will login to `quay.io` using the credentials specified by `<image><user>` and `<image><password>`.
-As it is not recommended to store credentials in clear in the `pom.xml`, we use a System propery (`my.secret.password`) to pass it when Maven is executed
-(with `mvn package -Dmy.secret.password="********").
+Before the image is pushed, it will login to `quay.io` using the credentials specified by `<registryId>`. The
+`<registryId>` defines the name of a `<server>` in your `settings.xml` file which may include encrypted passwords. While
+there is a `<user>` and `<password>` option, using a server in your `settings.xml` is the preferred way to authenticate
+with your registry.
 
 
 #[[##]]# Configure the JDK version used by the application image.
@@ -126,7 +124,7 @@ As it is not recommended to store credentials in clear in the `pom.xml`, we use 
 The application image is based on a runtime image provided by WildFly that contains all the runtimes required to run WildFly and your application.Push an application image to a container registry.
 At the moment, WildFly provides runtime images for OpenJDK 11 and OpenJDK 17.
 
-By default, the `image` goal uses the OpenJDK 11 runtime image. It is possible to use the OpenJDK 17 image instead by configuring the `<image><jdk-version>` to `17` as shown in the example below:
+By default, the `image` goal uses the OpenJDK 11 runtime image. It is possible to use the OpenJDK 17 image instead by configuring the `<jdk-version>` to `17` as shown in the example below:
 
 ```xml
 <project>
@@ -149,9 +147,7 @@ By default, the `image` goal uses the OpenJDK 11 runtime image. It is possible t
                     <layers>
                         <layer>jaxrs-server</layer>
                     </layers>
-                    <image>
-                        <jdk-version>17</jdk-version>
-                    </image>
+                    <jdk-version>17</jdk-version>
                 </configuration>
                 <executions>
                     <execution>

--- a/tests/standalone-tests/src/test/resources/test-project/image-layers-server-config-pom.xml
+++ b/tests/standalone-tests/src/test/resources/test-project/image-layers-server-config-pom.xml
@@ -26,9 +26,7 @@
                     </layers>
                     <provisioning-dir>image-layers-server-config</provisioning-dir>
                     <filename>test.war</filename>
-                    <image>
-                        <group>wildfly-image-layers-server-config-maven-plugin</group>
-                    </image>
+                    <group>wildfly-image-layers-server-config-maven-plugin</group>
                     <layers-configuration-file-name>standalone-core.xml</layers-configuration-file-name>
                 </configuration>
             </plugin>

--- a/tests/standalone-tests/src/test/resources/test-project/image-pom.xml
+++ b/tests/standalone-tests/src/test/resources/test-project/image-pom.xml
@@ -26,9 +26,7 @@
                     </layers>
                     <provisioning-dir>image-server</provisioning-dir>
                     <filename>test.war</filename>
-                    <image>
-                        <group>wildfly-maven-plugin</group>
-                    </image>
+                    <group>wildfly-maven-plugin</group>
                     <labels>
                         <version>1.0</version>
                         <description>This text illustrates \

--- a/tests/standalone-tests/src/test/resources/test-project/image-server-config-pom.xml
+++ b/tests/standalone-tests/src/test/resources/test-project/image-server-config-pom.xml
@@ -23,9 +23,7 @@
                     </feature-packs>
                     <provisioning-dir>image-server-config</provisioning-dir>
                     <filename>test.war</filename>
-                    <image>
-                        <group>wildfly-image-server-config-maven-plugin</group>
-                    </image>
+                    <group>wildfly-image-server-config-maven-plugin</group>
                     <server-config>standalone-microprofile.xml</server-config>
                 </configuration>
             </plugin>

--- a/tests/standalone-tests/src/test/resources/test-project/image-unknown-docker-binary-pom.xml
+++ b/tests/standalone-tests/src/test/resources/test-project/image-unknown-docker-binary-pom.xml
@@ -25,10 +25,8 @@
                         <layer>jaxrs-server</layer>
                     </layers>
                     <provisioning-dir>image-server</provisioning-dir>
-                    <image>
-                        <group>wildfly-maven-plugin</group>
-                        <docker-binary>focker-is-not-docker</docker-binary>
-                    </image>
+                    <group>wildfly-maven-plugin</group>
+                    <docker-binary>focker-is-not-docker</docker-binary>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
…eters in the ApplicationImageMojo. This creates better documentation and configuration.

Also add a new parameter for registryId so the username and password do not need to be defined in the POM.

https://issues.redhat.com/browse/WFMP-261