### PR TITLE
[WFMP-264] Bump version.org.jboss.logging.jboss-logging from 3.5.3.Final to 3.6.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
 
     <properties>
         <!-- WildFly/JBoss dependencies -->
-        <version.org.jboss.logging.jboss-logging>3.5.3.Final</version.org.jboss.logging.jboss-logging>
+        <version.org.jboss.logging.jboss-logging>3.6.0.Final</version.org.jboss.logging.jboss-logging>
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.common.wildfly-common>1.7.0.Final</version.org.wildfly.common.wildfly-common>
         <version.org.wildfly.plugin.tools>1.1.0.Final</version.org.wildfly.plugin.tools>


### PR DESCRIPTION
This came up while looking into updating jboss-logging in wildfly-core. See https://github.com/wildfly/wildfly-core/pull/6058#discussion_r1670686892 