### PR TITLE
Fix for WFMP-266, Allow to configure glow discovery to not scan the deployment

### DIFF
--- a/plugin/src/main/java/org/wildfly/plugin/common/Utils.java
+++ b/plugin/src/main/java/org/wildfly/plugin/common/Utils.java
@@ -119,8 +119,12 @@ public class Utils {
         if (!excludedLayers.isEmpty()) {
             throw new MojoExecutionException("excluded layers must be empty when enabling glow");
         }
-        if (!Files.exists(deploymentContent)) {
+        if (!Files.exists(deploymentContent) && !discoverProvisioningInfo.isIgnoreDeployment()) {
             throw new MojoExecutionException("A deployment is expected when enabling glow layer discovery");
+        }
+        if (discoverProvisioningInfo.isIgnoreDeployment()) {
+            log.warn(
+                    "The deployment will be not analyzed, WildFly Glow will produce a server based on configured add-ons and the default base layer.");
         }
         Path inProvisioningFile = null;
         Path glowOutputFolder = outputFolder.resolve("glow-scan");

--- a/plugin/src/main/java/org/wildfly/plugin/provision/GlowConfig.java
+++ b/plugin/src/main/java/org/wildfly/plugin/provision/GlowConfig.java
@@ -5,6 +5,7 @@
 package org.wildfly.plugin.provision;
 
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -29,13 +30,14 @@ public class GlowConfig {
     private boolean failsOnError = true;
     private boolean preview;
     private boolean verbose;
+    private boolean ignoreDeployment;
 
     public GlowConfig() {
     }
 
     public Arguments toArguments(Path deployment, Path inProvisioning, String layersConfigurationFileName) {
         final Set<String> profiles = profile != null ? Set.of(profile) : Set.of();
-        List<Path> lst = List.of(deployment);
+        List<Path> lst = ignoreDeployment ? Collections.emptyList() : List.of(deployment);
         Builder builder = Arguments.scanBuilder().setExecutionContext(context).setExecutionProfiles(profiles)
                 .setUserEnabledAddOns(addOns).setBinaries(lst).setSuggest(suggest).setJndiLayers(getLayersForJndi())
                 .setVersion(version)
@@ -190,5 +192,19 @@ public class GlowConfig {
      */
     public boolean isVerbose() {
         return verbose;
+    }
+
+    /**
+     * @param ignoreDeployment the ignoreDeployment to set
+     */
+    public void setIgnoreDeployment(boolean ignoreDeployment) {
+        this.ignoreDeployment = ignoreDeployment;
+    }
+
+    /**
+     * @return the ignoreDeployment
+     */
+    public boolean isIgnoreDeployment() {
+        return ignoreDeployment;
     }
 }

--- a/plugin/src/main/java/org/wildfly/plugin/provision/PackageServerMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/provision/PackageServerMojo.java
@@ -201,6 +201,8 @@ public class PackageServerMojo extends AbstractProvisionServerMojo {
      * <li>verbose: {@code true} | {@code false}. Display more information. The set of rules that selected Galleon layers are
      * printed. Default to {@code false}.</li>
      * <li>version: server version. Default being the latest released version.</li>
+     * <li>ignoreDeployment: The deployment will be not analyzed. A server based on the configured add-ons and the default base
+     * layer is provisioned. Default to {@code false}.</li>
      *
      * </ul>
      * </div>

--- a/tests/standalone-tests/src/test/java/org/wildfly/plugin/provision/PackageTest.java
+++ b/tests/standalone-tests/src/test/java/org/wildfly/plugin/provision/PackageTest.java
@@ -70,6 +70,17 @@ public class PackageTest extends AbstractProvisionConfiguredMojoTestCase {
     }
 
     @Test
+    public void testGlowNoDeploymentPackage() throws Exception {
+
+        final Mojo packageMojo = lookupConfiguredMojo(
+                AbstractWildFlyMojoTest.getPomFile("package-glow-no-deployment-pom.xml").toFile(), "package");
+        String[] layers = { "ee-core-profile-server", "microprofile-openapi" };
+        packageMojo.execute();
+        Path jbossHome = AbstractWildFlyMojoTest.getBaseDir().resolve("target").resolve("packaged-glow-no-deployment-server");
+        checkStandaloneWildFlyHome(jbossHome, 0, layers, null, true);
+    }
+
+    @Test
     public void testInvalidDeployment() throws Exception {
 
         final Mojo packageMojo = lookupConfiguredMojo(

--- a/tests/standalone-tests/src/test/resources/test-project/package-glow-no-deployment-pom.xml
+++ b/tests/standalone-tests/src/test/resources/test-project/package-glow-no-deployment-pom.xml
@@ -1,0 +1,32 @@
+<!--
+~ Copyright The WildFly Authors
+~ SPDX-License-Identifier: Apache-2.0
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>testing</groupId>
+    <artifactId>testing</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <configuration>
+                    <record-provisioning-state>true</record-provisioning-state>
+                    <provisioning-dir>packaged-glow-no-deployment-server</provisioning-dir>
+                    <discover-provisioning-info>
+                        <addOns>
+                            <addOn>openapi</addOn>
+                        </addOns>
+                        <ignoreDeployment>true</ignoreDeployment>
+                    </discover-provisioning-info>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFMP-266