### PR TITLE
Fix for WFMP-270, Plugin description should specify how to build a Hollow JAR

### DIFF
--- a/plugin/src/main/java/org/wildfly/plugin/provision/PackageServerMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/provision/PackageServerMojo.java
@@ -227,7 +227,8 @@ public class PackageServerMojo extends AbstractProvisionServerMojo {
     private GlowConfig discoverProvisioningInfo;
 
     /**
-     * Package the provisioned server into a WildFly Bootable JAR.
+     * Package the provisioned server into a WildFly Bootable JAR. In order to produce a hollow jar (a jar that doesn't contain
+     * a deployment) set the { @code skipDeployment } parameter.
      * <p>
      * Note that the produced fat JAR is ignored when running the {@code dev},{@code image},{@code start} or {@code run} goals.
      * </p>

--- a/plugin/src/site/markdown/package-example.md.vm
+++ b/plugin/src/site/markdown/package-example.md.vm
@@ -1,6 +1,6 @@
 # Package your application
 
-The package goal allows you to provision a server using Galleon, execute CLI commands and scripts to fine tune the server configuration, copy some 
+The package goal allows you to provision a server using Galleon or build a Bootable JAR (an executable fat JAR), execute CLI commands and scripts to fine tune the server configuration, copy some 
 extra content (e.g.: keystore, properties files) to the server installation and finally deploy your application.
 
 By default the server is provisioned in the ``target/server`` directory.
@@ -32,6 +32,53 @@ The example below shows how to produce the latest released ${appServerName} serv
                         contains the server content required to execute JAXRS applications -->
                         <layer>jaxrs-server</layer>
                     </layers>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            ...
+        </plugins>
+        ...
+    </build>
+...
+</project>
+```
+
+#[[##]]# Create a Bootable JAR
+
+The example below shows how to produce the latest released ${appServerName} server trimmed using 'jaxrs-server' Galleon layer and packaged as a Bootable JAR.
+
+```xml
+<project>
+    ...
+    <build>
+        ...
+        <plugins>
+            ...
+            <plugin>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>${project.artifactId}</artifactId>
+                <version>${project.version}</version>
+                <configuration>
+                    <feature-packs>
+                        <feature-pack>
+                            <!-- Latest released version -->
+                            <location>wildfly@maven(org.jboss.universe:community-universe)</location>
+                        </feature-pack>
+                    </feature-packs>
+                    <layers>
+                        <!-- Galleon layer allows to trim the installed server to your needs. The 'jaxrs-server' 
+                        contains the server content required to execute JAXRS applications -->
+                        <layer>jaxrs-server</layer>
+                    </layers>
+                <bootableJar>true</bootableJar>
+                <!-- Uncomment to produce a hollow JAR -->
+                <!-- <skipDeployment>true</skipDeployment> -->
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFMP-270

In addition, added documentation on how to produce a bootable JAR.