### PR TITLE
Fix for WFMP-277, Exception when discover-provisioning-info and feature-packs are set

### DIFF
--- a/plugin/src/main/java/org/wildfly/plugin/common/Utils.java
+++ b/plugin/src/main/java/org/wildfly/plugin/common/Utils.java
@@ -133,7 +133,6 @@ public class Utils {
             GalleonProvisioningConfig in = GalleonUtils.buildConfig(pm, featurePacks, layers, excludedLayers, galleonOptions,
                     layersConfigurationFileName);
             inProvisioningFile = glowOutputFolder.resolve("glow-in-provisioning.xml");
-            pm.newProvisioningBuilder(in).build().storeProvisioningConfig(in, outputFolder);
             try (Provisioning p = pm.newProvisioningBuilder(in).build()) {
                 p.storeProvisioningConfig(in, inProvisioningFile);
             }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFMP-277

Reported by: https://github.com/wildfly/wildfly-maven-plugin/discussions/580