### PR TITLE
Upgrade prospero-metadata to 1.3.0.Beta2

### DIFF
--- a/plugin/src/main/java/org/wildfly/plugin/provision/ChannelMavenArtifactRepositoryManager.java
+++ b/plugin/src/main/java/org/wildfly/plugin/provision/ChannelMavenArtifactRepositoryManager.java
@@ -186,8 +186,7 @@ public class ChannelMavenArtifactRepositoryManager implements MavenRepoManager, 
 
     public void done(Path home) throws MavenUniverseException, IOException {
         ChannelManifest channelManifest = channelSession.getRecordedChannel();
-        final ManifestVersionRecord currentVersions = new ManifestVersionResolver(localCachePath, system)
-                .getCurrentVersions(channels);
+        final ManifestVersionRecord currentVersions = ManifestVersionResolver.getCurrentVersions(channelSession);
         ProsperoMetadataUtils.generate(home, channels, channelManifest, currentVersions);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <version.org.wildfly.launcher>1.0.0.Beta3</version.org.wildfly.launcher>
         <version.org.wildfly>32.0.1.Final</version.org.wildfly>
         <version.org.wildfly.channel>1.2.1.Final</version.org.wildfly.channel>
-        <version.org.wildfly.prospero>1.2.1.Final</version.org.wildfly.prospero>
+        <version.org.wildfly.prospero>1.3.0.Final</version.org.wildfly.prospero>
         <!-- maven dependencies -->
         <version.javax.inject.javax.inject>1</version.javax.inject.javax.inject>
         <version.org.apache.maven.maven-core>3.9.4</version.org.apache.maven.maven-core>


### PR DESCRIPTION
This is the prospero-metadata version minor relevant to next EAP stream.