### PR TITLE
Repeatable teststuite, exluding wrong versions of slf4j-api & commons-lang3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -247,6 +247,16 @@
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-core</artifactId>
                 <version>${version.org.apache.maven.maven-core}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.commons</groupId>
+                        <artifactId>commons-lang3</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven</groupId>
@@ -294,6 +304,12 @@
                 <groupId>org.apache.maven.shared</groupId>
                 <artifactId>maven-common-artifact-filters</artifactId>
                 <version>${version.org.apache.maven.shared.filter}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven.wagon</groupId>
@@ -458,6 +474,12 @@
                 <groupId>org.jboss.galleon</groupId>
                 <artifactId>galleon-core</artifactId>
                 <version>${version.org.jboss.galleon}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>

--- a/tests/bootable-tests/src/test/java/org/wildfly/plugin/bootable/PackageBootableTest.java
+++ b/tests/bootable-tests/src/test/java/org/wildfly/plugin/bootable/PackageBootableTest.java
@@ -6,6 +6,7 @@ package org.wildfly.plugin.bootable;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 
 import org.apache.maven.plugin.Mojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -42,7 +43,7 @@ public class PackageBootableTest extends AbstractProvisionConfiguredMojoTestCase
         String deploymentName = "ROOT.war";
         Path rootWar = AbstractWildFlyMojoTest.getBaseDir().resolve("target").resolve(deploymentName);
         Path testWar = AbstractWildFlyMojoTest.getBaseDir().resolve("target").resolve("test.war");
-        Files.copy(testWar, rootWar);
+        Files.copy(testWar, rootWar, StandardCopyOption.REPLACE_EXISTING);
         Files.delete(testWar);
         packageMojo.execute();
         String[] layers = { "jaxrs-server" };

--- a/tests/bootable-tests/src/test/resources/test-project/package-bootable-pom.xml
+++ b/tests/bootable-tests/src/test/resources/test-project/package-bootable-pom.xml
@@ -43,6 +43,7 @@
                     <record-provisioning-state>true</record-provisioning-state>
                     <provisioning-dir>packaged-bootable-server</provisioning-dir>
                     <bootable-jar>true</bootable-jar>
+                    <overwrite-provisioned-server>true</overwrite-provisioned-server>
                 </configuration>
             </plugin>
         </plugins>

--- a/tests/standalone-tests/src/test/resources/test-project/package-invalid-deployment-pom.xml
+++ b/tests/standalone-tests/src/test/resources/test-project/package-invalid-deployment-pom.xml
@@ -43,6 +43,7 @@
                     </extra-server-content-dirs>
                     <record-provisioning-state>true</record-provisioning-state>
                     <provisioning-dir>packaged-invalid-dep-server</provisioning-dir>
+                    <overwrite-provisioned-server>true</overwrite-provisioned-server>
                 </configuration>
             </plugin>
         </plugins>

--- a/tests/standalone-tests/src/test/resources/test-project/package-invalid-deployment2-pom.xml
+++ b/tests/standalone-tests/src/test/resources/test-project/package-invalid-deployment2-pom.xml
@@ -44,6 +44,7 @@
                     </extra-server-content-dirs>
                     <record-provisioning-state>true</record-provisioning-state>
                     <provisioning-dir>packaged-invalid-dep2-server</provisioning-dir>
+                    <overwrite-provisioned-server>true</overwrite-provisioned-server>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
@jfdenise requested to open this upstream PR too.

Both slf4j-api and commons-lang3 transitive deps will still be present,
but in different versions that better suit us. This makes it easier to
perform automatic dependency alignments.