### PR TITLE
Add commons-logging-jboss-logmanager dependency to test to avoid CNF Exception

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
 
         <version.org.eclipse.sisu>0.3.5</version.org.eclipse.sisu>
         <version.org.twdata.maven>2.4.0</version.org.twdata.maven>
+        <version.org.jboss.logmanager.commons-logging-jboss-logmanager>1.0.3.Final</version.org.jboss.logmanager.commons-logging-jboss-logmanager>
 
         <!-- other dependencies -->
         <version.com.bernardomg.maven.skins>2.3.3</version.com.bernardomg.maven.skins>
@@ -507,6 +508,11 @@
                 <groupId>org.jboss.slf4j</groupId>
                 <artifactId>slf4j-jboss-logging</artifactId>
                 <version>${version.org.jboss.logging.slf4j-jboss-logging}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.logmanager</groupId>
+                <artifactId>commons-logging-jboss-logmanager</artifactId>
+                <version>${version.org.jboss.logmanager.commons-logging-jboss-logmanager}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/tests/bootable-tests/pom.xml
+++ b/tests/bootable-tests/pom.xml
@@ -72,6 +72,12 @@
             <artifactId>maven-resolver-util</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- to fix ClassNotFoundException org.jboss.logmanager.LogManager in plexus -->
+        <dependency>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>commons-logging-jboss-logmanager</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- to fix slf4j warning when provisioning -->
         <dependency>
             <groupId>org.jboss.slf4j</groupId>

--- a/tests/domain-tests/pom.xml
+++ b/tests/domain-tests/pom.xml
@@ -36,6 +36,12 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- to fix ClassNotFoundException org.jboss.logmanager.LogManager in plexus -->
+        <dependency>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>commons-logging-jboss-logmanager</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/tests/standalone-tests/pom.xml
+++ b/tests/standalone-tests/pom.xml
@@ -87,6 +87,12 @@
             <artifactId>channel-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- to fix ClassNotFoundException org.jboss.logmanager.LogManager in plexus -->
+        <dependency>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>commons-logging-jboss-logmanager</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- to fix slf4j warning when provisioning -->
         <dependency>
             <groupId>org.jboss.slf4j</groupId>


### PR DESCRIPTION
The Exception doesn't make the tests to fail but is displayed in the test logs. 