### PR TITLE
Do not set the org.jboss.logmanager.LogManager as the log manager sin…

### DIFF
--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -62,7 +62,6 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <systemPropertyVariables>
-                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                         <jboss.home>${jboss.home}</jboss.home>
                         <jboss-as.home>${jboss.home}</jboss-as.home>
                         <wildfly.test.version>${version.org.wildfly}</wildfly.test.version>


### PR DESCRIPTION
…ce we do not have a dependency on it for tests.

replaces #620 