### PR TITLE
Fix for WFMP-290, Upgrade to Glow 1.3.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
 
         <!-- galleon properties -->
         <version.org.jboss.galleon>6.0.4.Final</version.org.jboss.galleon>
-        <version.org.wildfly.glow>1.2.0.Final</version.org.wildfly.glow>
+        <version.org.wildfly.glow>1.3.0.Final</version.org.wildfly.glow>
         <plugin.fork.embedded>true</plugin.fork.embedded>
         <!-- used by tests -->
         <version.org.jboss.logging.slf4j-jboss-logging>1.2.1.Final</version.org.jboss.logging.slf4j-jboss-logging>


### PR DESCRIPTION
This upgrade makes WildFly Glow to retrieve its metadata from maven, that is something that blocks some users to use the WildFly Maven Plugin with Glow feature (in some pipeline context where only maven repositories are allowed to connect to).