### PR TITLE
[WFMP-301] When the provisioningDir is defined, we need to revert bac…

### DIFF
--- a/plugin/src/main/java/org/wildfly/plugin/server/AbstractServerStartMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/server/AbstractServerStartMojo.java
@@ -279,7 +279,7 @@ public abstract class AbstractServerStartMojo extends AbstractStartMojo {
                 if (provisioningDir == null) {
                     cachedJBossHome = Path.of(project.getBuild().getDirectory(), Utils.WILDFLY_DEFAULT_DIR);
                 } else {
-                    cachedJBossHome = Path.of(project.getBuild().getDirectory(), provisioningDir);
+                    cachedJBossHome = Path.of(project.getBuild().getDirectory()).resolve(provisioningDir);
                 }
             } else {
                 cachedJBossHome = Path.of(jbossHome);


### PR DESCRIPTION
…k to using the previous behavior of resoling the directory based on a fully qualified path.

https://issues.redhat.com/browse/WFMP-301