### PR TITLE
Make bootable jar packaging more visible in the doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A Maven plug-in for WildFly Application Server. This plugin allows you to:
   * Run a standalone server within Maven
   * Galleon provisioning of a server.
   * Packaging of a fully configured server containing application deployment.
+  * Packaging of a fully configured server and application as a Bootable JAR (an executable fat JAR).
 
 Plugin documentation is at https://docs.wildfly.org/wildfly-maven-plugin
 

--- a/plugin/src/site/markdown/index.md.vm
+++ b/plugin/src/site/markdown/index.md.vm
@@ -1,7 +1,7 @@
 
 # ${project.name} (${project.artifactId})
 
-  The ${project.artifactId} is used to provision a server using Galleon, package your application in Galleon provisioned server, 
+  The ${project.artifactId} is used to provision a server or Bootable JAR (an executable fat JAR) using Galleon, package your application in Galleon provisioned server, 
   deploy, redeploy, undeploy or run your application. You can also deploy or undeploy
   artifacts, such as JDBC drivers, and add or remove resources. There is also the ability to execute CLI commands.
 
@@ -17,7 +17,7 @@
 
   * [${pluginPrefix}:deploy-artifact](./deploy-artifact-mojo.html) deploys an arbitrary artifact to the server.
 
-  * [${pluginPrefix}:package](./package-mojo.html) produces a fully configured server installation using Galleon and WildFly CLI that contains your application.
+  * [${pluginPrefix}:package](./package-mojo.html) produces a fully configured server installation or Bootable JAR using Galleon and WildFly CLI that contains your application.
 
   * [${pluginPrefix}:provision](./provision-mojo.html) produces a server installation using Galleon.
 
@@ -34,6 +34,9 @@
   * [${pluginPrefix}:run](./run-mojo.html) runs the application server and deploys your application.
 
   * [${pluginPrefix}:start](./start-mojo.html) starts the application server and leaves the process running. In most cases
+    the [shutdown goal](./shutdown-mojo.html) be executed to ensure the server is shutdown.
+
+  * [${pluginPrefix}:start-jar](./start-jar-mojo.html) starts the Bootable JAR and leaves the process running. In most cases
     the [shutdown goal](./shutdown-mojo.html) be executed to ensure the server is shutdown.
 
   * [${pluginPrefix}:shutdown](./shutdown-mojo.html) shuts down a running application server.

--- a/plugin/src/site/markdown/usage.md.vm
+++ b/plugin/src/site/markdown/usage.md.vm
@@ -59,7 +59,7 @@ mvn ${pluginPrefix}:dev
 
 #[[##]]# The `${pluginPrefix}:package` Goal
 
-The `${pluginPrefix}:package` goal will provision a server, execute CLI commands and deploy your application.
+The `${pluginPrefix}:package` goal will provision a server or a Bootable JAR (an executable fat JAR), execute CLI commands and deploy your application.
 
 To execute the package goal type the following on the command line:
 


### PR DESCRIPTION
Currently doc on bootable JAR is hidden in the package goal doc only. Adding this information to the top level indexes and README help discover the feature when searching the web.