### PR TITLE
Fix for WFMP-348, Add support for variant in WildFly Glow configuration

### DIFF
--- a/plugin/src/main/java/org/wildfly/plugin/common/Utils.java
+++ b/plugin/src/main/java/org/wildfly/plugin/common/Utils.java
@@ -158,7 +158,7 @@ public class Utils {
                 p.storeProvisioningConfig(in, inProvisioningFile);
             }
         }
-        Arguments arguments = discoverProvisioningInfo.toArguments(deploymentContents, inProvisioningFile,
+        Arguments arguments = discoverProvisioningInfo.toArguments(log, deploymentContents, inProvisioningFile,
                 layersConfigurationFileName);
         log.info("Glow is scanning... ");
         ScanResults results;

--- a/plugin/src/main/java/org/wildfly/plugin/provision/GlowConfig.java
+++ b/plugin/src/main/java/org/wildfly/plugin/provision/GlowConfig.java
@@ -9,6 +9,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
 import org.wildfly.glow.Arguments;
 import org.wildfly.glow.OutputFormat;
 import org.wildfly.glow.ScanArguments.Builder;
@@ -29,20 +31,28 @@ public class GlowConfig {
     private Set<String> layersForJndi = Set.of();
     private Set<String> excludedArchives = Set.of();
     private boolean failsOnError = true;
+    @Deprecated
     private boolean preview;
     private boolean verbose;
     private boolean ignoreDeployment;
+    private String serverVariant;
 
     public GlowConfig() {
     }
 
-    public Arguments toArguments(List<Path> lst, Path inProvisioning, String layersConfigurationFileName) {
+    public Arguments toArguments(Log log, List<Path> lst, Path inProvisioning, String layersConfigurationFileName)
+            throws Exception {
         final Set<String> profiles = profile != null ? Set.of(profile) : Set.of();
         List<Path> deployments = ignoreDeployment ? Collections.emptyList() : lst;
+        if (serverVariant != null && preview) {
+            throw new MojoExecutionException("Preview can't be set when a server variant has been set.");
+        }
+        if (preview) {
+            log.warn("preview option has been deprecated, use <server-variant>[server variant]</server-variant> option");
+        }
         Builder builder = Arguments.scanBuilder().setExecutionContext(context).setExecutionProfiles(profiles)
                 .setUserEnabledAddOns(addOns).setBinaries(deployments).setSuggest(suggest).setJndiLayers(getLayersForJndi())
                 .setVersion(version)
-                .setTechPreview(preview)
                 .setExcludeArchivesFromScan(excludedArchives)
                 .setVerbose(verbose)
                 .setSpaces(spaces)
@@ -52,6 +62,12 @@ public class GlowConfig {
         }
         if (layersConfigurationFileName != null) {
             builder.setConfigName(layersConfigurationFileName);
+        }
+        if (preview) {
+            builder.setTechPreview(preview);
+        }
+        if (serverVariant != null) {
+            builder.setServerVariant(serverVariant);
         }
         return builder.build();
     }

--- a/plugin/src/main/java/org/wildfly/plugin/provision/PackageServerMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/provision/PackageServerMojo.java
@@ -217,7 +217,8 @@ public class PackageServerMojo extends AbstractProvisionServerMojo {
      * <li>failsOnError: true|false. If errors are detected (missing datasource, missing messaging broker, ambiguous JNDI call,
      * provisioning is aborted. Default to {@code false}</li>
      * <li>layersForJndi: List of Galleon layers required by some JNDI calls located in your application.</li>
-     * <li>preview: {@code true} | {@code false}. Use preview feature-packs. Default to {@code false}.</li>
+     * <li>preview: {@code true} | {@code false}. Use preview feature-packs. Default to {@code false}. DEPRECATED, use
+     * {@code server-variant}</li>
      * <li>profile: {@code ha}. Default being non ha server configuration.</li>
      * <li>suggest: {@code true} | {@code false}. Display addOns that you can use to enhance discovered provisioning
      * configuration. Default to {@code false}.</li>
@@ -233,7 +234,7 @@ public class PackageServerMojo extends AbstractProvisionServerMojo {
      * <li>spaces: List of spaces to enable. A space brings extra galleon feature-packs to the provisioning (eg:
      * {@code incubating} to
      * include the feature-packs that are in the incubating state.</li>
-     *
+     * <li>server-variant: server variant. Default being the WildFly server. An example of server variant is `preview`.</li>
      * </ul>
      * </div>
      *

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
 
         <!-- galleon properties -->
         <version.org.jboss.galleon>7.0.5.Final</version.org.jboss.galleon>
-        <version.org.wildfly.glow>2.0.0.Beta1</version.org.wildfly.glow>
+        <version.org.wildfly.glow>2.0.0.Beta2</version.org.wildfly.glow>
         <plugin.fork.embedded>true</plugin.fork.embedded>
 
         <!-- checkstyle configuration -->

--- a/tests/standalone-tests/src/test/java/org/wildfly/plugin/provision/PackageTest.java
+++ b/tests/standalone-tests/src/test/java/org/wildfly/plugin/provision/PackageTest.java
@@ -27,6 +27,7 @@ import org.apache.maven.artifact.handler.ArtifactHandler;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.Mojo;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -122,6 +123,27 @@ public class PackageTest extends AbstractProjectMojoTest {
         packageMojo.execute();
         Path jbossHome = resolvePath("packaged-glow-no-deployment-server");
         TestEnvironment.checkStandaloneWildFlyHome(jbossHome, 0, layers, null, true);
+    }
+
+    @Test
+    @InjectMojo(goal = "package", pom = "package-preview-glow-pom.xml")
+    public void testGlowPreviewPackage(final Mojo packageMojo) throws Exception {
+        String[] layers = { "ee-core-profile-server", "microprofile-openapi" };
+        packageMojo.execute();
+        Path jbossHome = resolvePath("packaged-preview-glow-server");
+        TestEnvironment.checkStandaloneWildFlyHome(jbossHome, 1, layers, null, true);
+    }
+
+    @Test
+    @InjectMojo(goal = "package", pom = "package-unknown-variant-glow-pom.xml")
+    public void testGlowUnknownVariantPackage(final Mojo packageMojo) throws Exception {
+        try {
+            packageMojo.execute();
+            Assertions.fail("Execution should have failed");
+        } catch (MojoExecutionException ex) {
+            // XXX OK, expected.
+            assertTrue(ex.getLocalizedMessage().contains("Unknown variant foo. Variants are ["));
+        }
     }
 
     @Test

--- a/tests/standalone-tests/src/test/resources/test-project/package-preview-glow-pom.xml
+++ b/tests/standalone-tests/src/test/resources/test-project/package-preview-glow-pom.xml
@@ -1,0 +1,38 @@
+<!--
+    ~ Copyright The WildFly Authors
+    ~ SPDX-License-Identifier: Apache-2.0
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>testing</groupId>
+    <artifactId>testing</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <configuration>
+                    <filename>test.war</filename>
+                    <record-provisioning-state>true</record-provisioning-state>
+                    <provisioning-dir>packaged-preview-glow-server</provisioning-dir>
+                    <discover-provisioning-info>
+                        <addOns>
+                            <addOn>openapi</addOn>
+                        </addOns>
+                        <version>${version.org.wildfly}</version>
+                        <server-variant>preview</server-variant>
+                    </discover-provisioning-info>
+                    <galleon-options>
+                        <!-- Fork the process to avoid a two controller-client's from being on the class path -->
+                        <jboss-fork-embedded>true</jboss-fork-embedded>
+                    </galleon-options>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/tests/standalone-tests/src/test/resources/test-project/package-unknown-variant-glow-pom.xml
+++ b/tests/standalone-tests/src/test/resources/test-project/package-unknown-variant-glow-pom.xml
@@ -1,0 +1,38 @@
+<!--
+    ~ Copyright The WildFly Authors
+    ~ SPDX-License-Identifier: Apache-2.0
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>testing</groupId>
+    <artifactId>testing</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <configuration>
+                    <filename>test.war</filename>
+                    <record-provisioning-state>true</record-provisioning-state>
+                    <provisioning-dir>packaged-unknown-variant-glow-server</provisioning-dir>
+                    <discover-provisioning-info>
+                        <addOns>
+                            <addOn>openapi</addOn>
+                        </addOns>
+                        <version>${version.org.wildfly}</version>
+                        <server-variant>foo</server-variant>
+                    </discover-provisioning-info>
+                    <galleon-options>
+                        <!-- Fork the process to avoid a two controller-client's from being on the class path -->
+                        <jboss-fork-embedded>true</jboss-fork-embedded>
+                    </galleon-options>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>


### PR DESCRIPTION
Issue: https://redhat.atlassian.net/browse/WFMP-348

Incorporates a bump to WildFly Glow 2.0.0.Beta2