### PR TITLE
Fix for WFMP-352, Upgrade to WildFly Glow 2.0.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
 
         <!-- galleon properties -->
         <version.org.jboss.galleon>7.0.5.Final</version.org.jboss.galleon>
-        <version.org.wildfly.glow>2.0.0.Beta2</version.org.wildfly.glow>
+        <version.org.wildfly.glow>2.0.0.Final</version.org.wildfly.glow>
         <plugin.fork.embedded>true</plugin.fork.embedded>
 
         <!-- checkstyle configuration -->


### PR DESCRIPTION
Issue: https://redhat.atlassian.net/browse/WFMP-352