### PR TITLE
[WFMP-353] Provision from file path directly to preserve <feature> elements

### DIFF
--- a/plugin/src/main/java/org/wildfly/plugin/provision/AbstractProvisionServerMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/provision/AbstractProvisionServerMojo.java
@@ -13,6 +13,7 @@ import java.net.MalformedURLException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -305,8 +306,22 @@ abstract class AbstractProvisionServerMojo extends AbstractMojo {
             MojoExecutionException, IOException, XMLStreamException {
         GalleonBuilder galleonBuilder = new GalleonBuilder();
         galleonBuilder.addArtifactResolver(artifactResolver);
+        // When a provisioning file is supplied and no plugin-side feature-packs
+        // are configured, route the file path directly to the provisioning
+        // manager. The Galleon API roundtrip
+        // (loadProvisioningConfig -> provision(GalleonProvisioningConfig))
+        // silently drops <feature> elements nested under <config> because the
+        // GalleonProvisioningConfig <-> ProvisioningConfig conversion erases
+        // ConfigItemContainer items when the configuration crosses the
+        // isolated core class loader. Using the path-based provision call
+        // preserves the parsed ProvisioningConfig as-is.
+        Path resolvedProvisioningFile = resolvePath(project, provisioningFile.toPath());
+        boolean provisionFromFile = featurePacks.isEmpty()
+                && Files.exists(resolvedProvisioningFile);
         GalleonProvisioningConfig config = buildGalleonConfig(galleonBuilder);
-        ProvisioningBuilder builder = galleonBuilder.newProvisioningBuilder(config);
+        ProvisioningBuilder builder = provisionFromFile
+                ? galleonBuilder.newProvisioningBuilder(resolvedProvisioningFile)
+                : galleonBuilder.newProvisioningBuilder(config);
         try (Provisioning pm = builder
                 .setInstallationHome(home)
                 .setMessageWriter(new MvnMessageWriter(getLog()))
@@ -317,19 +332,29 @@ abstract class AbstractProvisionServerMojo extends AbstractMojo {
                 Path targetPath = Paths.get(project.getBuild().getDirectory());
                 Path file = targetPath.resolve(PLUGIN_PROVISIONING_FILE);
                 getLog().info("Dry-run execution, generating provisioning.xml file: " + file);
-                pm.storeProvisioningConfig(config, file);
+                if (provisionFromFile) {
+                    Files.createDirectories(targetPath);
+                    Files.copy(resolvedProvisioningFile, file,
+                            StandardCopyOption.REPLACE_EXISTING);
+                } else {
+                    pm.storeProvisioningConfig(config, file);
+                }
                 return;
             }
             getLog().info("Provisioning server in " + home);
             PluginProgressTracker.initTrackers(pm, new MavenJBossLogger(getLog()));
-            pm.provision(config, galleonOptions);
+            if (provisionFromFile) {
+                pm.provision(resolvedProvisioningFile, galleonOptions);
+            } else {
+                pm.provision(config, galleonOptions);
+            }
             // Check that at least the standalone or domain directories have been generated.
             if (!Files.exists(home.resolve("standalone")) && !Files.exists(home.resolve("domain"))) {
                 getLog().error("Invalid galleon provisioning, no server provisioned in " + home + ". Make sure "
                         + "that the list of Galleon feature-packs and Galleon layers are properly configured.");
                 throw new MojoExecutionException("Invalid plugin configuration, no server provisioned.");
             }
-            if (!recordProvisioningState) {
+            if (!recordProvisioningState && !provisionFromFile) {
                 Path file = home.resolve(PLUGIN_PROVISIONING_FILE);
                 pm.storeProvisioningConfig(config, file);
             }


### PR DESCRIPTION
Issue: https://redhat.atlassian.net/browse/WFMP-353

## Summary

When the `provision` goal is configured with a `provisioning-file` and no
plugin-side `<feature-packs>`, inline `<feature>` elements nested under
`<config>` are silently dropped. The plugin currently parses the file
into a `GalleonProvisioningConfig`, then calls
`Provisioning.provision(GalleonProvisioningConfig, ...)`. Inside the
isolated galleon-core class loader, the
`GalleonProvisioningConfig` → `ProvisioningConfig` converter only copies
layers, properties and config-deps from `GalleonConfigurationWithLayers`
and discards the `ConfigItemContainer` items (features, feature-groups)
carried by the parsed `ConfigModel`.

User-visible symptom: a `provisioning.xml` like

```xml
<config name="standalone.xml" model="standalone">
    <layers><include name="cloud-server"/></layers>
    <feature spec="subsystem.undertow.configuration.filter.expression-filter">
        <param name="expression-filter" value="my-filter"/>
        <param name="expression" value="path('/x') -> rewrite('/y')"/>
    </feature>
</config>
```

provisions a server in which the filter is missing, with no warning in
the build log. Even an intentionally invalid spec name does not fail the
build.

This patch routes the provisioning file directly to
`Provisioning.provision(Path, options)` when no plugin-side feature-packs
are configured. The internal `ProvisioningConfig` is fed into
`ProvisioningManager` without crossing the API boundary, so `<feature>`,
`<feature-group>`, `<packages>` and `<config-deps>` are preserved. The
dry-run path copies `provisioning.xml` verbatim to the target directory
instead of round-tripping through `storeProvisioningConfig`.

## Verification

1. Create a `provisioning.xml` with the snippet above.
2. Bind the `provision` goal in the `package` phase, point
   `provisioning-file` at the file, leave `<feature-packs>` empty.
3. Build with the unpatched plugin: `BUILD SUCCESS`, but
   `standalone/configuration/standalone.xml` contains no
   `expression-filter` and `target/server/.galleon/provisioning.xml`
   records only `<layers>`, no `<feature>`.
4. Build with this patch: `BUILD SUCCESS`, the filter shows up in the
   generated `standalone.xml`; an invalid spec name now fails the build
   with `Failed to locate feature spec ...`.

## Risk

Limited to the `provisioning-file` + empty `<feature-packs>` configuration
path. Other provisioning paths (channel-based, plugin-configured
feature-packs) are unchanged. The dry-run fallback is a verbatim file
copy, which is closer to the user's input than the previous
`storeProvisioningConfig` round-trip.
