### PR TITLE
Preserve Maven repository session for channel resolution

### DIFF
--- a/plugin/src/main/java/org/wildfly/plugin/provision/ChannelMavenArtifactRepositoryManager.java
+++ b/plugin/src/main/java/org/wildfly/plugin/provision/ChannelMavenArtifactRepositoryManager.java
@@ -23,7 +23,6 @@ import java.util.regex.Pattern;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
-import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
@@ -74,9 +73,8 @@ public class ChannelMavenArtifactRepositoryManager implements MavenRepoManager, 
             throw new MojoExecutionException("No channel specified.");
         }
         this.log = log;
-        session = MavenRepositorySystemUtils.newSession();
+        session = new DefaultRepositorySystemSession(contextSession);
         this.repositories = repositories;
-        session.setLocalRepositoryManager(contextSession.getLocalRepositoryManager());
         session.setOffline(offline);
         for (ChannelConfiguration channelConfiguration : channels) {
             this.channels.add(channelConfiguration.toChannel(offline ? Collections.emptyList() : repositories));


### PR DESCRIPTION
## Summary

`ChannelMavenArtifactRepositoryManager` built a fresh
`DefaultRepositorySystemSession` and only copied the local repository
manager from the build session. Authentication, mirror and proxy
selectors as well as configuration properties were dropped, so channel
manifest resolution against an authenticated Maven repository failed
with `HTTP 401` even when `settings.xml` supplied valid credentials.
This addresses the requirement in #401 to support channels stored in
authenticated Maven repositories.

The fix uses the `DefaultRepositorySystemSession` copy constructor to
inherit the build session state and keeps the explicit `setOffline`
call so the plugin's `offlineProvisioning` parameter still wins.

## Verification

Built locally against an isolated Maven cache with a private
repository configured in `settings.xml`. The provision goal resolves
the channel manifest without `401 Unauthorized` (`grep -c "status
code: 401"` of the build log returns `0`). The bootable-tests module,
which exercises channel-based provisioning, builds green.

## Risk

Minimal. The copy constructor preserves the existing build session,
which is already used by the rest of the build, and the explicit
`setOffline(offline)` call keeps the plugin's offline switch
authoritative.
