### PR TITLE
fix: inject session proxy into Aether repositories before embedded resolves

### DIFF
--- a/core/src/main/java/org/wildfly/plugin/core/MavenRepositoriesEnricher.java
+++ b/core/src/main/java/org/wildfly/plugin/core/MavenRepositoriesEnricher.java
@@ -105,7 +105,8 @@ public class MavenRepositoriesEnricher {
     }
 
     /**
-     * Inject the session-level proxy/mirror/auth onto each repository.
+     * Returns the repository list to use for resolution, with the session-level
+     * proxy/mirror/auth injected onto every entry.
      *
      * Aether's HttpTransporter reads {@code repository.getProxy()} directly
      * and never consults {@code session.getProxySelector()}. The Maven CLI
@@ -116,18 +117,21 @@ public class MavenRepositoriesEnricher {
      * Call this helper after {@link #enrich} so downstream resolves honour
      * the settings.xml proxy regardless of the calling context.
      *
-     * @param repoSystem   the Aether repository system (may be null - call is a no-op)
-     * @param session      the Aether repository session (may be null - call is a no-op)
-     * @param repositories the repository list to enrich in place
+     * The input list is treated as read-only and never mutated. When injection
+     * cannot or need not be performed (null inputs, empty list), the input
+     * list itself is returned unchanged.
+     *
+     * @param repoSystem   the Aether repository system (may be {@code null} - input list is returned unchanged)
+     * @param session      the Aether repository session (may be {@code null} - input list is returned unchanged)
+     * @param repositories the repository list to enrich; never mutated, may be {@code null} or empty
+     * @return the enriched repository list when injection is possible; otherwise the original input list
      */
-    public static void injectSessionProxies(RepositorySystem repoSystem, RepositorySystemSession session,
-            List<RemoteRepository> repositories) {
+    public static List<RemoteRepository> injectSessionProxies(RepositorySystem repoSystem,
+            RepositorySystemSession session, List<RemoteRepository> repositories) {
         if (repoSystem == null || session == null || repositories == null || repositories.isEmpty()) {
-            return;
+            return repositories;
         }
-        final List<RemoteRepository> enriched = repoSystem.newResolutionRepositories(session, repositories);
-        repositories.clear();
-        repositories.addAll(enriched);
+        return repoSystem.newResolutionRepositories(session, repositories);
     }
 
     private static Set<String> getUrls(List<RemoteRepository> repositories) {

--- a/core/src/main/java/org/wildfly/plugin/core/MavenRepositoriesEnricher.java
+++ b/core/src/main/java/org/wildfly/plugin/core/MavenRepositoriesEnricher.java
@@ -19,6 +19,8 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.settings.Proxy;
 import org.apache.maven.settings.Settings;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.repository.RepositoryPolicy;
 
@@ -100,6 +102,32 @@ public class MavenRepositoriesEnricher {
                 repositories.add(builder.build());
             }
         }
+    }
+
+    /**
+     * Inject the session-level proxy/mirror/auth onto each repository.
+     *
+     * Aether's HttpTransporter reads {@code repository.getProxy()} directly
+     * and never consults {@code session.getProxySelector()}. The Maven CLI
+     * normally copies the session-level proxy onto each repository via
+     * {@link RepositorySystem#newResolutionRepositories} before invoking a
+     * Mojo. Embedded callers (plugin test harness, custom invokers) skip
+     * that step, so the proxy is dropped before Aether sees the repository.
+     * Call this helper after {@link #enrich} so downstream resolves honour
+     * the settings.xml proxy regardless of the calling context.
+     *
+     * @param repoSystem   the Aether repository system (may be null - call is a no-op)
+     * @param session      the Aether repository session (may be null - call is a no-op)
+     * @param repositories the repository list to enrich in place
+     */
+    public static void injectSessionProxies(RepositorySystem repoSystem, RepositorySystemSession session,
+            List<RemoteRepository> repositories) {
+        if (repoSystem == null || session == null || repositories == null || repositories.isEmpty()) {
+            return;
+        }
+        final List<RemoteRepository> enriched = repoSystem.newResolutionRepositories(session, repositories);
+        repositories.clear();
+        repositories.addAll(enriched);
     }
 
     private static Set<String> getUrls(List<RemoteRepository> repositories) {

--- a/plugin/src/main/java/org/wildfly/plugin/cli/ExecuteCommandsMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/cli/ExecuteCommandsMojo.java
@@ -225,8 +225,9 @@ public class ExecuteCommandsMojo extends AbstractServerConnection {
             return;
         }
         MavenRepositoriesEnricher.enrich(mavenSession, project, repositories);
-        MavenRepositoriesEnricher.injectSessionProxies(repoSystem, session, repositories);
-        mavenRepoManager = new MavenArtifactRepositoryManager(repoSystem, session, repositories);
+        final List<RemoteRepository> effectiveRepositories = MavenRepositoriesEnricher
+                .injectSessionProxies(repoSystem, session, repositories);
+        mavenRepoManager = new MavenArtifactRepositoryManager(repoSystem, session, effectiveRepositories);
         final CommandConfiguration.Builder cmdConfigBuilder = CommandConfiguration
                 .of(this::createClient, this::getClientConfiguration)
                 .addCommands(commands)

--- a/plugin/src/main/java/org/wildfly/plugin/cli/ExecuteCommandsMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/cli/ExecuteCommandsMojo.java
@@ -225,6 +225,7 @@ public class ExecuteCommandsMojo extends AbstractServerConnection {
             return;
         }
         MavenRepositoriesEnricher.enrich(mavenSession, project, repositories);
+        MavenRepositoriesEnricher.injectSessionProxies(repoSystem, session, repositories);
         mavenRepoManager = new MavenArtifactRepositoryManager(repoSystem, session, repositories);
         final CommandConfiguration.Builder cmdConfigBuilder = CommandConfiguration
                 .of(this::createClient, this::getClientConfiguration)

--- a/plugin/src/main/java/org/wildfly/plugin/dev/DevMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/dev/DevMojo.java
@@ -58,6 +58,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.eclipse.aether.repository.RemoteRepository;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.galleon.ProvisioningException;
 import org.jboss.galleon.api.GalleonBuilder;
@@ -518,14 +519,15 @@ public class DevMojo extends AbstractServerStartMojo {
     }
 
     @Override
-    protected MavenRepoManager createMavenRepoManager() throws MojoExecutionException {
+    protected MavenRepoManager createMavenRepoManager(final List<RemoteRepository> effectiveRepositories)
+            throws MojoExecutionException {
         if (channels == null || channels.isEmpty()) {
             return offlineProvisioning ? new MavenArtifactRepositoryManager(repoSystem, session)
-                    : new MavenArtifactRepositoryManager(repoSystem, session, repositories);
+                    : new MavenArtifactRepositoryManager(repoSystem, session, effectiveRepositories);
         } else {
             try {
                 return new ChannelMavenArtifactRepositoryManager(channels,
-                        repoSystem, session, repositories,
+                        repoSystem, session, effectiveRepositories,
                         getLog(), offlineProvisioning);
             } catch (MalformedURLException | UnresolvedMavenArtifactException ex) {
                 throw new MojoExecutionException(ex.getLocalizedMessage(), ex);

--- a/plugin/src/main/java/org/wildfly/plugin/provision/AbstractProvisionServerMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/provision/AbstractProvisionServerMojo.java
@@ -246,14 +246,14 @@ abstract class AbstractProvisionServerMojo extends AbstractMojo {
                     " of %s:%s", project.getGroupId(), project.getArtifactId()));
             return;
         }
-        enrichRepositories();
+        final List<RemoteRepository> effectiveRepositories = enrichRepositories();
         if (channels == null || channels.isEmpty()) {
             artifactResolver = offlineProvisioning ? new MavenArtifactRepositoryManager(repoSystem, repoSession)
-                    : new MavenArtifactRepositoryManager(repoSystem, repoSession, repositories);
+                    : new MavenArtifactRepositoryManager(repoSystem, repoSession, effectiveRepositories);
         } else {
             try {
                 artifactResolver = new ChannelMavenArtifactRepositoryManager(channels,
-                        repoSystem, repoSession, repositories,
+                        repoSystem, repoSession, effectiveRepositories,
                         getLog(), offlineProvisioning);
             } catch (MalformedURLException | UnresolvedMavenArtifactException ex) {
                 throw new MojoExecutionException(ex.getLocalizedMessage(), ex);
@@ -293,9 +293,9 @@ abstract class AbstractProvisionServerMojo extends AbstractMojo {
         }
     }
 
-    protected void enrichRepositories() throws MojoExecutionException {
+    protected List<RemoteRepository> enrichRepositories() throws MojoExecutionException {
         MavenRepositoriesEnricher.enrich(session, project, repositories);
-        MavenRepositoriesEnricher.injectSessionProxies(repoSystem, repoSession, repositories);
+        return MavenRepositoriesEnricher.injectSessionProxies(repoSystem, repoSession, repositories);
     }
 
     protected abstract String getGoal();

--- a/plugin/src/main/java/org/wildfly/plugin/provision/AbstractProvisionServerMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/provision/AbstractProvisionServerMojo.java
@@ -295,6 +295,7 @@ abstract class AbstractProvisionServerMojo extends AbstractMojo {
 
     protected void enrichRepositories() throws MojoExecutionException {
         MavenRepositoriesEnricher.enrich(session, project, repositories);
+        MavenRepositoriesEnricher.injectSessionProxies(repoSystem, repoSession, repositories);
     }
 
     protected abstract String getGoal();

--- a/plugin/src/main/java/org/wildfly/plugin/server/AbstractStartMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/server/AbstractStartMojo.java
@@ -140,6 +140,7 @@ public abstract class AbstractStartMojo extends AbstractServerConnection {
         // Setting the mavenRepoManager is not thread-safe, however creating it more than once won't hurt anything
         if (initialized.compareAndSet(false, true)) {
             MavenRepositoriesEnricher.enrich(mavenSession, project, repositories);
+            MavenRepositoriesEnricher.injectSessionProxies(repoSystem, session, repositories);
             mavenRepoManager = createMavenRepoManager();
         }
     }

--- a/plugin/src/main/java/org/wildfly/plugin/server/AbstractStartMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/server/AbstractStartMojo.java
@@ -140,13 +140,15 @@ public abstract class AbstractStartMojo extends AbstractServerConnection {
         // Setting the mavenRepoManager is not thread-safe, however creating it more than once won't hurt anything
         if (initialized.compareAndSet(false, true)) {
             MavenRepositoriesEnricher.enrich(mavenSession, project, repositories);
-            MavenRepositoriesEnricher.injectSessionProxies(repoSystem, session, repositories);
-            mavenRepoManager = createMavenRepoManager();
+            final List<RemoteRepository> effectiveRepositories = MavenRepositoriesEnricher
+                    .injectSessionProxies(repoSystem, session, repositories);
+            mavenRepoManager = createMavenRepoManager(effectiveRepositories);
         }
     }
 
-    protected MavenRepoManager createMavenRepoManager() throws MojoExecutionException {
-        return new MavenArtifactRepositoryManager(repoSystem, session, repositories);
+    protected MavenRepoManager createMavenRepoManager(final List<RemoteRepository> effectiveRepositories)
+            throws MojoExecutionException {
+        return new MavenArtifactRepositoryManager(repoSystem, session, effectiveRepositories);
     }
 
     protected abstract Path getServerHome() throws MojoExecutionException, MojoFailureException;


### PR DESCRIPTION
# fix: inject session proxy into Aether repositories before embedded resolves

## Problem
Aether's `HttpTransporter` reads `repository.getProxy()` directly; it does not consult `session.getProxySelector()`. The Maven CLI normally runs `RepositorySystem.newResolutionRepositories(session, repos)` before Mojo invocation, which copies the session-level proxy onto every `RemoteRepository`. Embedded callers (`maven-plugin-testing-harness` 3.5.1, custom invokers) skip that step, so `repository.getProxy() == null` and downstream resolves connect directly.

## Fix
New helper `MavenRepositoriesEnricher.injectSessionProxies(repoSystem, session, repos)` wraps the `newResolutionRepositories` call. Invoked next to each `MavenRepositoriesEnricher.enrich` call site that the plugin uses before building its own `MavenArtifactRepositoryManager`:

- `AbstractProvisionServerMojo.enrichRepositories` — provision / package goals
- `ExecuteCommandsMojo.execute` — `execute-commands` goal (`LocalCLIExecutor.resolveCLI` resolves `wildfly-cli` on its own through the resulting `MavenArtifactRepositoryManager`)
- `AbstractStartMojo.init` — covers every `AbstractStartMojo` subclass (`StartMojo`, `RunMojo`, `DevMojo`, `StartJarMojo`)

Idempotent for the Maven CLI.

## Reproducer
`maven-plugin-testing-harness` 3.5.1 + Maven Resolver 1.9.27 + fresh local m2. Run any of the goals above behind an HTTP proxy declared in `~/.m2/settings.xml`:

```
Could not transfer artifact ... : Connect timed out
```

`session.getProxySelector().getProxy(repo)` returns the configured proxy, but `HttpTransporter` never sees it because `repository.getProxy() == null`.
