### PR TITLE
[WFMP-354] perf(provision): bulk-resolve Galleon artifacts via Aether

### DIFF
--- a/plugin/src/main/java/org/wildfly/plugin/provision/ChannelMavenArtifactRepositoryManager.java
+++ b/plugin/src/main/java/org/wildfly/plugin/provision/ChannelMavenArtifactRepositoryManager.java
@@ -13,6 +13,7 @@ import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -23,13 +24,14 @@ import java.util.regex.Pattern;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
-import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.resolution.ArtifactRequest;
+import org.eclipse.aether.resolution.ArtifactResolutionException;
 import org.eclipse.aether.resolution.VersionRangeRequest;
 import org.eclipse.aether.resolution.VersionRangeResolutionException;
 import org.eclipse.aether.resolution.VersionRangeResult;
@@ -74,9 +76,8 @@ public class ChannelMavenArtifactRepositoryManager implements MavenRepoManager, 
             throw new MojoExecutionException("No channel specified.");
         }
         this.log = log;
-        session = MavenRepositorySystemUtils.newSession();
+        session = new DefaultRepositorySystemSession(contextSession);
         this.repositories = repositories;
-        session.setLocalRepositoryManager(contextSession.getLocalRepositoryManager());
         session.setOffline(offline);
         for (ChannelConfiguration channelConfiguration : channels) {
             this.channels.add(channelConfiguration.toChannel(offline ? Collections.emptyList() : repositories));
@@ -101,6 +102,65 @@ public class ChannelMavenArtifactRepositoryManager implements MavenRepoManager, 
         channelSession = new ChannelSession(this.channels, factory);
         localCachePath = contextSession.getLocalRepositoryManager().getRepository().getBasedir().toPath();
         this.system = system;
+    }
+
+    /**
+     * Bulk artifact pre-fetch. The default {@link MavenRepoManager#resolveAll}
+     * iterates {@link #resolve(MavenArtifact)} sequentially: one HTTP round-trip
+     * per artifact, dominating cold-cache provisioning time. This override pre-fetches
+     * all artifacts that already have a concrete version in one call to Aether's
+     * {@link RepositorySystem#resolveArtifacts(RepositorySystemSession, java.util.Collection)},
+     * which uses Aether's connector thread pool (default 5 threads) to download in
+     * parallel. After the pre-fetch every {@link #resolve(MavenArtifact)} call hits
+     * the local cache.
+     *
+     * <p>
+     * This path is only triggered when the Galleon provisioning option
+     * {@code jboss-bulk-resolve-artifacts} is set to {@code true} (see
+     * {@code WfInstallPlugin.resolveArtifactsInCache}). Without that option the
+     * upstream plugin keeps calling {@link #resolve(MavenArtifact)} per artifact
+     * and this override is unused.
+     *
+     * <p>
+     * Pre-fetch failures are non-fatal: any artifact not pre-fetched falls
+     * through to the per-artifact {@link #resolve(MavenArtifact)} path which keeps
+     * the existing channel/direct-resolve fallback semantics.
+     */
+    @Override
+    public void resolveAll(Collection<MavenArtifact> artifacts) throws MavenUniverseException {
+        if (artifacts == null || artifacts.isEmpty()) {
+            return;
+        }
+        List<ArtifactRequest> requests = new ArrayList<>(artifacts.size());
+        for (MavenArtifact a : artifacts) {
+            if (a.getVersion() == null || a.getVersion().isEmpty()) {
+                continue;
+            }
+            DefaultArtifact ax = new DefaultArtifact(a.getGroupId(), a.getArtifactId(),
+                    a.getClassifier() == null ? "" : a.getClassifier(),
+                    a.getExtension() == null ? "jar" : a.getExtension(),
+                    a.getVersion());
+            ArtifactRequest req = new ArtifactRequest();
+            req.setArtifact(ax);
+            req.setRepositories(repositories);
+            requests.add(req);
+        }
+        if (!requests.isEmpty()) {
+            try {
+                system.resolveArtifacts(session, requests);
+            } catch (ArtifactResolutionException ex) {
+                // Partial failure is fine: the per-artifact resolve below retries the misses
+                // through the channel/direct-resolve fallback.
+                if (log.isDebugEnabled()) {
+                    log.debug("Bulk pre-fetch reported missing artifacts; falling back to per-artifact resolve. "
+                            + ex.getMessage());
+                }
+            }
+        }
+        // Fall back to the per-artifact path; cached artifacts are now local hits.
+        for (MavenArtifact a : artifacts) {
+            resolve(a);
+        }
     }
 
     @Override

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -128,6 +128,7 @@
                     <provisioning-dir>${project.build.directory}/wildfly</provisioning-dir>
                     <galleon-options>
                         <jboss-fork-embedded>${plugin.fork.embedded}</jboss-fork-embedded>
+                        <jboss-bulk-resolve-artifacts>true</jboss-bulk-resolve-artifacts>
                     </galleon-options>
                 </configuration>
                 <executions>


### PR DESCRIPTION
Issue: https://redhat.atlassian.net/browse/WFMP-354

# perf(provision): bulk-resolve Galleon artifacts via Aether

## Change
`ChannelMavenArtifactRepositoryManager` overrides `MavenRepoManager.resolveAll(Collection)`. Concrete-version artifacts are pre-fetched in one `RepositorySystem.resolveArtifacts(...)` call; Aether's connector thread pool (default 5) downloads them in parallel. The per-artifact `resolve(MavenArtifact)` path is kept as fallback so channel-recording semantics are preserved and any artifact missed by the bulk pre-fetch is retried individually.

The bulk `resolveAll` path is gated by Galleon option `<jboss-bulk-resolve-artifacts>true</jboss-bulk-resolve-artifacts>`. Enabled in `tests/pom.xml` so it is exercised by the existing provision-server fixture. Without the option the per-artifact `resolve(MavenArtifact)` flow is unchanged.

Independent of that option, the repository session is now constructed as `new DefaultRepositorySystemSession(contextSession)` instead of `MavenRepositorySystemUtils.newSession() + setLocalRepositoryManager(...)`. This affects every resolution path through `ChannelMavenArtifactRepositoryManager`: it inherits the caller's mirror/proxy/auth selectors, not only its local repository manager.

## Cold-cache measurement

| Phase | Before | After |
|---|---|---|
| Galleon provisioning | 172.2 s | 77.3 s (-55%) |
| `mvn install` end-to-end | 218.6 s | 128.2 s (-41%) |

Warm-cache runs unchanged.
