### PR TITLE
[WFMP-361] Do not just blindly set the debug parameters on the comman…

### DIFF
--- a/plugin/src/main/java/org/wildfly/plugin/dev/DevMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/dev/DevMojo.java
@@ -229,6 +229,12 @@ public class DevMojo extends AbstractServerStartMojo {
     private CommandExecutor commandExecutor;
 
     /**
+     * Starts the server with debugging enabled.
+     */
+    @Parameter(property = "wildfly.debug", defaultValue = "true")
+    private boolean debug;
+
+    /**
      * The CLI commands to execute before the deployment is deployed.
      */
     @Parameter(property = PropertyNames.COMMANDS)
@@ -535,7 +541,7 @@ public class DevMojo extends AbstractServerStartMojo {
 
     @Override
     protected CommandBuilder createCommandBuilder(final Path jbossHome) throws MojoExecutionException {
-        return createStandaloneCommandBuilder(jbossHome, serverConfig).setDebug();
+        return createStandaloneCommandBuilder(jbossHome, serverConfig);
     }
 
     /**
@@ -676,6 +682,11 @@ public class DevMojo extends AbstractServerStartMojo {
     @Override
     protected boolean isAllowProvisioning() {
         return overwriteProvisionedServer || super.isAllowProvisioning();
+    }
+
+    @Override
+    protected boolean isDebugEnabled() {
+        return debug;
     }
 
     private ScanResults scanDeployment(GalleonBuilder pm) throws Exception {

--- a/plugin/src/main/java/org/wildfly/plugin/server/AbstractServerStartMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/server/AbstractServerStartMojo.java
@@ -141,7 +141,7 @@ public abstract class AbstractServerStartMojo extends AbstractStartMojo {
         if (Utils.isNotNullOrEmpty(javaOpts)) {
             commandBuilder.setJavaOptions(javaOpts);
         }
-        if (debug) {
+        if (isDebugEnabled()) {
             commandBuilder.addJavaOptions(String.format("-agentlib:jdwp=transport=dt_socket,server=y,suspend=%s,address=%s:%d",
                     debugSuspend ? "y" : "n", debugHost, debugPort));
         }

--- a/plugin/src/main/java/org/wildfly/plugin/server/AbstractStartMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/server/AbstractStartMojo.java
@@ -72,7 +72,7 @@ public abstract class AbstractStartMojo extends AbstractServerConnection {
      * Starts the server with debugging enabled.
      */
     @Parameter(property = "wildfly.debug", defaultValue = "false")
-    protected boolean debug;
+    private boolean debug;
 
     /**
      * Sets the hostname to listen on for debugging. An {@code *} means all hosts.
@@ -304,5 +304,9 @@ public abstract class AbstractStartMojo extends AbstractServerConnection {
             }
         }
         return super.getManagementHostName();
+    }
+
+    protected boolean isDebugEnabled() {
+        return debug;
     }
 }

--- a/plugin/src/main/java/org/wildfly/plugin/server/StartJarMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/server/StartJarMojo.java
@@ -94,7 +94,7 @@ public class StartJarMojo extends AbstractStartMojo {
         if (Utils.isNotNullOrEmpty(javaOpts)) {
             commandBuilder.setJavaOptions(javaOpts);
         }
-        if (debug) {
+        if (isDebugEnabled()) {
             commandBuilder.addJavaOptions(String.format("-agentlib:jdwp=transport=dt_socket,server=y,suspend=%s,address=%s:%d",
                     debugSuspend ? "y" : "n", debugHost, debugPort));
         }


### PR DESCRIPTION
…d builder in dev mode. We should only set them, and honor the other settings, if the debug parameter was not previously set.

https://redhat.atlassian.net/browse/WFMP-361